### PR TITLE
DENA-969: rename plugin to uw-kafka-config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       uses: goreleaser/goreleaser-action@v6
       with:
         version: latest
-        args: release --rm-dist
+        args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-tflint-ruleset-kafka-config
+tflint-ruleset-uw-kafka-config

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,10 +16,10 @@ builds:
     hooks:
       post:
         - mkdir -p ./dist/raw
-        - cp "{{ .Path }}" "./dist/raw/{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+        - cp "{{ .Path }}" "./dist/raw/tflint-ruleset-uw-kafka-config_{{ .Os }}_{{ .Arch }}"
 archives:
   - id: zip
-    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "tflint-ruleset-uw-kafka-config_{{ .Os }}_{{ .Arch }}"
     format: zip
     files:
       - none*

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,7 @@ builds:
       - linux_arm64
       - windows_386
       - windows_amd64
+    binary: tflint-ruleset-uw-kafka-config
     hooks:
       post:
         - mkdir -p ./dist/raw

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@ test:
 	go test ./...
 
 build:
-	go build
+	go build -o tflint-ruleset-uw-kafka-config
 
 install: build
 	mkdir -p ~/.tflint.d/plugins
-	mv ./tflint-ruleset-kafka-config ~/.tflint.d/plugins
+	mv ./tflint-ruleset-uw-kafka-config ~/.tflint.d/plugins
 
 lint:
 	pre-commit run --all-files

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a [tflint](https://github.com/terraform-linters/tflint) [plugin](https:/
 You can install the plugin with `tflint --init`. Declare a config in `.tflint.hcl` as follows:
 
 ```hcl
-plugin "kafka-config" {
+plugin "uw-kafka-config" {
   enabled = true
 
   version = "x.y.z"

--- a/main.go
+++ b/main.go
@@ -10,8 +10,7 @@ import (
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
 		RuleSet: &tflint.BuiltinRuleSet{
-			Name:    "kafka-config",
-			Version: "0.1.0",
+			Name: "uw-kafka-config",
 			Rules: []tflint.Rule{
 				rules.NewMskModuleBackendRule(),
 			},

--- a/main.go
+++ b/main.go
@@ -7,10 +7,14 @@ import (
 	"github.com/utilitywarehouse/tflint-ruleset-kafka-config/rules"
 )
 
+// set by goreleaser at build time: https://goreleaser.com/cookbooks/using-main.version/
+var version = "dev"
+
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
 		RuleSet: &tflint.BuiltinRuleSet{
-			Name: "uw-kafka-config",
+			Name:    "uw-kafka-config",
+			Version: version,
 			Rules: []tflint.Rule{
 				rules.NewMskModuleBackendRule(),
 			},


### PR DESCRIPTION
tflint will look for the executable named tflint-ruleset${plugin-name}, including in the released artefacts. 

So I had to hardcode tflint-ruleset-uw-kafka-config in several places
