### PR TITLE
DENA-969: more restrictive backend rule

### DIFF
--- a/rules/msk_module_backend.go
+++ b/rules/msk_module_backend.go
@@ -11,7 +11,9 @@ import (
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )
 
-// MskModuleBackendRule checks whether an MSK module has an S3 backend defined with a key in the format {{env}}/{{cluster}}-{{team-name}}.
+// MskModuleBackendRule checks whether an MSK module has an S3 backend defined with the following restrictions:
+//   - the key is in the format ${env}-${platform}/${msk-cluster}-${team-name}
+//   - the bucket contains the environment in its name
 type MskModuleBackendRule struct {
 	tflint.DefaultRule
 }
@@ -184,7 +186,7 @@ func (r *MskModuleBackendRule) checkBackendKeyFormat(runner tflint.Runner, backe
 	if key != expectedKey {
 		err := runner.EmitIssue(
 			r,
-			fmt.Sprintf("backend key must have the following format: {{env}}/{{cluster}}-{{team-name}}. Expected: '%s', current: '%s'", expectedKey, key),
+			fmt.Sprintf("backend key must have the following format: ${env}-${platform}/${msk-cluster}-${team-name}. Expected: '%s', current: '%s'", expectedKey, key),
 			keyAttr.Range,
 		)
 		if err != nil {

--- a/rules/msk_module_backend.md
+++ b/rules/msk_module_backend.md
@@ -1,6 +1,9 @@
 # msk_module_backend
 
-Requires an S3 backend to be defined, with a key that has as suffix the name of the team.
+## Requirements
+Requires an S3 backend to be defined with the following properties:
+- the key as the format ${env}-${platform}/${msk-cluster}-${team-name}
+- the bucket contains the environment in its name
 
 ## Example
 
@@ -23,10 +26,10 @@ terraform {
   }
 }
 
-// backend key doesn't have the team's suffix
+// backend key doesn't follow the format and the bucket doesn't have the environment in its name
 terraform {
   backend "s3" {
-    bucket = "mybucket"
+    bucket = "mybucket-without-env"
     key    = "key-without-team-suffix"
     region = "us-east-1"
   }
@@ -35,12 +38,12 @@ terraform {
 
 ### Good example
 
-Good for team `pubsub`:
+Good for team `pubsub` in the `dev` environment, on the `AWS` platform, on the `msk-shared` cluster :
 ```hcl
 terraform {
   backend "s3" {
-    bucket = "mybucket"
-    key    = "dev-aws/msk-pubsub"
+    bucket = "my-dev-bucket"
+    key    = "dev-aws/msk-shared-pubsub"
     region = "us-east-1"
   }
 }
@@ -49,10 +52,13 @@ terraform {
 ## Why
 
 We want to avoid team mixing their states due to copy/paste issues.
+
 With this rule, all the details for the bucket will always be specified in the kafka-cluster-config repository where we have a module per team and each team has a unique name.
+
+Having the key and bucket name in the required format, makes sure we avoid copy/paste issues between environments, platforms, teams, etc 
 
 ## How To Fix
 
-Define the S3 backend in the team's module, having the key as the team's suffix.
+Define the S3 backend in the team's module, satisfying the [requirements](#requirements).
 
 See [good example](#good-example)

--- a/rules/msk_module_backend_test.go
+++ b/rules/msk_module_backend_test.go
@@ -123,7 +123,7 @@ terraform {
 			Expected: helper.Issues{
 				{
 					Rule:    rule,
-					Message: "backend key must have the following format: {{env}}/{{cluster}}-{{team-name}}. Expected: 'dev-gcp/msk-cluster-pubsub', current: 'prod-aws/msk-cluster-pubsub'",
+					Message: "backend key must have the following format: ${env}-${platform}/${msk-cluster}-${team-name}. Expected: 'dev-gcp/msk-cluster-pubsub', current: 'prod-aws/msk-cluster-pubsub'",
 					Range: hcl.Range{
 						Filename: "backend.tf",
 						Start:    hcl.Pos{Line: 5, Column: 5},
@@ -146,7 +146,7 @@ terraform {
 			Expected: helper.Issues{
 				{
 					Rule:    rule,
-					Message: "backend key must have the following format: {{env}}/{{cluster}}-{{team-name}}. Expected: 'dev-merit/msk-cluster-otel', current: 'dev-merit/dummy-cluster-otel'",
+					Message: "backend key must have the following format: ${env}-${platform}/${msk-cluster}-${team-name}. Expected: 'dev-merit/msk-cluster-otel', current: 'dev-merit/dummy-cluster-otel'",
 					Range: hcl.Range{
 						Filename: "backend.tf",
 						Start:    hcl.Pos{Line: 5, Column: 5},
@@ -169,7 +169,7 @@ terraform {
 			Expected: helper.Issues{
 				{
 					Rule:    rule,
-					Message: "backend key must have the following format: {{env}}/{{cluster}}-{{team-name}}. Expected: 'dev-aws/msk-cluster-pubsub', current: 'dev-aws/msk-cluster-dummy-key'",
+					Message: "backend key must have the following format: ${env}-${platform}/${msk-cluster}-${team-name}. Expected: 'dev-aws/msk-cluster-pubsub', current: 'dev-aws/msk-cluster-dummy-key'",
 					Range: hcl.Range{
 						Filename: "backend.tf",
 						Start:    hcl.Pos{Line: 5, Column: 5},

--- a/rules/msk_module_backend_test.go
+++ b/rules/msk_module_backend_test.go
@@ -68,17 +68,39 @@ terraform {
 			},
 		},
 		{
-			Name:    "backend doesn't specify properties",
+			Name:    "backend doesn't specify the bucket",
 			WorkDir: defaultWorkDir,
 			Files: map[string]string{"backend.tf": `
 terraform {
   backend "s3" {
+    key = "dev-aws/kafka-shared-msk-pubsub"
   }
 }`},
 			Expected: helper.Issues{
 				{
 					Rule:    rule,
-					Message: "the s3 backend should specify the details inside the kafka MSK module",
+					Message: "the s3 backend should specify the bucket inside the kafka MSK module",
+					Range: hcl.Range{
+						Filename: "backend.tf",
+						Start:    hcl.Pos{Line: 3, Column: 3},
+						End:      hcl.Pos{Line: 3, Column: 15},
+					},
+				},
+			},
+		},
+		{
+			Name:    "backend doesn't specify the key",
+			WorkDir: defaultWorkDir,
+			Files: map[string]string{"backend.tf": `
+terraform {
+  backend "s3" {
+    bucket = "dummy-dev--bucket"
+  }
+}`},
+			Expected: helper.Issues{
+				{
+					Rule:    rule,
+					Message: "the s3 backend should specify the key inside the kafka MSK module",
 					Range: hcl.Range{
 						Filename: "backend.tf",
 						Start:    hcl.Pos{Line: 3, Column: 3},
@@ -93,7 +115,7 @@ terraform {
 			Files: map[string]string{"backend.tf": `
 terraform {
   backend "s3" {
-    bucket = "mybucket"
+    bucket = "my-dev-bucket"
     key    = "prod-aws/msk-cluster-pubsub"
     region = "us-east-1"
   }
@@ -116,7 +138,7 @@ terraform {
 			Files: map[string]string{"backend.tf": `
 terraform {
   backend "s3" {
-    bucket = "mybucket"
+    bucket = "my-dev-bucket"
     key    = "dev-merit/dummy-cluster-otel"
     region = "us-east-1"
   }
@@ -139,7 +161,7 @@ terraform {
 			Files: map[string]string{"backend.tf": `
 terraform {
   backend "s3" {
-    bucket = "mybucket"
+    bucket = "my-dev-bucket"
     key    = "dev-aws/msk-cluster-dummy-key"
     region = "us-east-1"
   }
@@ -157,6 +179,29 @@ terraform {
 			},
 		},
 		{
+			Name:    "backend bucket doesn't contain the env",
+			WorkDir: filepath.Join("config", "prod-aws", "msk-cluster", "pubsub"),
+			Files: map[string]string{"backend.tf": `
+terraform {
+  backend "s3" {
+    bucket = "my-bucket"
+    key    = "prod-aws/msk-cluster-pubsub"
+    region = "us-east-1"
+  }
+}`},
+			Expected: helper.Issues{
+				{
+					Rule:    rule,
+					Message: "backend bucket doesn't contain the env of the module. Current value 'my-bucket' should contain env 'prod'",
+					Range: hcl.Range{
+						Filename: "backend.tf",
+						Start:    hcl.Pos{Line: 4, Column: 5},
+						End:      hcl.Pos{Line: 4, Column: 25},
+					},
+				},
+			},
+		},
+		{
 			Name:    "good backend defined in second terraform config",
 			WorkDir: defaultWorkDir,
 			Files: map[string]string{
@@ -167,7 +212,7 @@ terraform{
 				"backend.tf": `
 terraform {
   backend "s3" {
-	bucket = "mybucket"
+	bucket = "my-dev-bucket"
 	key    = "dev-aws/kafka-shared-msk-pubsub"
 	region = "us-east-1"
   }


### PR DESCRIPTION
Implemented a more restrictive backend rule:
- msk backend: key must have specific format ${env}-${platform}/${msk-cluster}-${team-name}
- msk backend: bucket must be specified and must contain the env

With this approach we should avoid all possible mistakes like copy paste across envs/platforms/teams.