### PR TITLE
Add rule to enforce consuming only topics in current module

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ plugin "uw-kafka-config" {
 | Name                                              | Description                                                                              |
 |---------------------------------------------------|------------------------------------------------------------------------------------------|
 | [msk_module_backend](rules/msk_module_backend.md) | Requires an S3 backend to be defined, with a key that has as suffix the name of the team (taken from the current directory name) |
+| [`msk_app_topics`](rules/msk_app_topics.md) | Requires apps consume from and produce to only topics define in their module. |
 
 
 ## Building the plugin

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.22.0
 	github.com/stretchr/testify v1.7.2
 	github.com/terraform-linters/tflint-plugin-sdk v0.21.0
+	github.com/zclconf/go-cty v1.15.0
 )
 
 require (
@@ -27,7 +28,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
-	github.com/zclconf/go-cty v1.15.0 // indirect
 	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/net v0.29.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ func main() {
 			Version: version,
 			Rules: []tflint.Rule{
 				rules.NewMskModuleBackendRule(),
+				&rules.MskAppTopics{},
 			},
 		},
 	})

--- a/rules/msk_app_topics.go
+++ b/rules/msk_app_topics.go
@@ -1,0 +1,174 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/logger"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// MskAppTopics checks whether an MSK module only consumes from topics
+// defined in the module.
+type MskAppTopics struct {
+	tflint.DefaultRule
+}
+
+func (r *MskAppTopics) Name() string {
+	return "msk_app_topics"
+}
+
+func (r *MskAppTopics) Enabled() bool {
+	return true
+}
+
+func (r *MskAppTopics) Link() string {
+	return ReferenceLink(r.Name())
+}
+
+func (r *MskAppTopics) Severity() tflint.Severity {
+	return tflint.ERROR
+}
+
+func (r *MskAppTopics) Check(runner tflint.Runner) error {
+	path, err := runner.GetModulePath()
+	if err != nil {
+		return fmt.Errorf("getting module path: %w", err)
+	}
+	if !path.IsRoot() {
+		logger.Debug("skipping child module")
+		return nil
+	}
+
+	// resourceNameMap: resource_name -> topic_name (for mapping variables to EvalCtx)
+	// moduleTopics: topic_name -> struct{} (for name lookups)
+	resourceNameMap, moduleTopics, err := getKafkaTopics(runner)
+	if err != nil {
+		return err
+	}
+	logger.Debug("found topics", "topics", resourceNameMap)
+
+	modules, err := runner.GetModuleContent(
+		&hclext.BodySchema{
+			Blocks: []hclext.BlockSchema{
+				{
+					Type:       "module",
+					LabelNames: []string{"name"},
+					Body: &hclext.BodySchema{
+						Attributes: []hclext.AttributeSchema{
+							{Name: "produce_topics"},
+							{Name: "consume_topics"},
+						},
+					},
+				},
+			},
+		},
+		nil,
+	)
+	if err != nil {
+		return fmt.Errorf("getting modules: %w", err)
+	}
+	evalCtx := buildTopicNameContext(resourceNameMap)
+	for _, block := range modules.Blocks {
+		for _, topicAttr := range []string{"consume_topics", "produce_topics"} {
+			if err := r.reportExternalTopics(runner, topicAttr, block, evalCtx, moduleTopics); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func getKafkaTopics(runner tflint.Runner) (map[string]string, map[string]struct{}, error) {
+	resourceContents, err := runner.GetResourceContent(
+		"kafka_topic",
+		&hclext.BodySchema{
+			Attributes: []hclext.AttributeSchema{{Name: "name"}},
+		},
+		nil,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting kafka_topic contents: %w", err)
+	}
+
+	resourceNameMap := map[string]string{}
+	topicNameMap := map[string]struct{}{}
+	for _, topicResource := range resourceContents.Blocks {
+		resourceName := topicResource.Labels[1]
+		nameAttr := topicResource.Body.Attributes["name"]
+
+		var name string
+		diags := gohcl.DecodeExpression(nameAttr.Expr, nil, &name)
+		if diags.HasErrors() {
+			return nil, nil, fmt.Errorf(
+				"decoding name for kafka_topic '%s': %w",
+				resourceName,
+				diags,
+			)
+		}
+		resourceNameMap[resourceName] = name
+		topicNameMap[name] = struct{}{}
+	}
+
+	return resourceNameMap, topicNameMap, nil
+}
+
+func buildTopicNameContext(topicNameMap map[string]string) *hcl.EvalContext {
+	// tflint doesn't do any variable expansion, so we manually build an
+	// EvalContext that we can use for lookups of variables like
+	// `kafka_topic.my_topic.name` via a lookup like:
+	// EvalContext.Variables["kafka_topic"]["my_topic"]["name"]
+	nameMap := map[string]cty.Value{}
+	for topicResourceName, topicName := range topicNameMap {
+		nameMap[topicResourceName] = cty.ObjectVal(
+			map[string]cty.Value{"name": cty.StringVal(topicName)},
+		)
+	}
+
+	return &hcl.EvalContext{
+		Variables: map[string]cty.Value{
+			"kafka_topic": cty.ObjectVal(nameMap),
+		},
+	}
+}
+
+func (r *MskAppTopics) reportExternalTopics(
+	runner tflint.Runner,
+	attrName string,
+	block *hclext.Block,
+	evalCtx *hcl.EvalContext,
+	moduleTopicNames map[string]struct{},
+) error {
+	topicAttr, ok := block.Body.Attributes[attrName]
+	if !ok {
+		logger.Debug("skipping block, doesn't provide producer/consumer", "labels", block.Labels)
+		return nil
+	}
+
+	val, diags := topicAttr.Expr.Value(evalCtx)
+	if diags.HasErrors() {
+		return fmt.Errorf("evaluating topic names: %w", diags)
+	}
+	for _, v := range val.AsValueSlice() {
+		name := v.AsString()
+		if _, ok := moduleTopicNames[name]; !ok {
+			err := runner.EmitIssue(
+				r,
+				fmt.Sprintf(
+					"'%s' may only contain topics defined in the current module but '%s' is not",
+					attrName,
+					name,
+				),
+				topicAttr.Range,
+			)
+			if err != nil {
+				return fmt.Errorf("emitting issue: %w", err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/rules/msk_app_topics.md
+++ b/rules/msk_app_topics.md
@@ -1,0 +1,36 @@
+# `msk_app_topics`
+
+Requires that any `consume_topics` or `produce_topics` contain only topics that
+are defined in the current module.
+
+## Example
+
+### Bad examples
+
+``` hcl
+resource "kafka_topic" "pubsub_examples" {
+  name = "pubsub.examples"
+}
+
+module "consumer" {
+  # bad: "some-team.some.topic.v1" not defined in this module
+  consume_topics = ["some-team.some.topic.v1"]
+}
+```
+
+### Good example
+
+``` hcl
+resource "kafka_topic" "pubsub_examples" {
+  name = "pubsub.examples"
+}
+
+
+module "consumer" {
+  # good: topic is in this module
+  consume_topics = [kafka_topic.pubsub_examples.name]
+
+  # good: also fine if you use the name directly
+  produce_topics = "pubsub.examples"
+}
+```

--- a/rules/msk_app_topics_test.go
+++ b/rules/msk_app_topics_test.go
@@ -1,0 +1,172 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/require"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_MskAppTopics(t *testing.T) {
+	rule := &MskAppTopics{}
+
+	for _, tc := range []struct {
+		name     string
+		files    map[string]string
+		expected helper.Issues
+	}{
+		{
+			name: "consuming from topic not in module",
+			files: map[string]string{
+				"file.tf": `
+module "consumer" {
+	consume_topics = ["some_topic"]
+}
+`,
+			},
+			expected: []*helper.Issue{
+				{
+					Rule:    rule,
+					Message: "'consume_topics' may only contain topics defined in the current module but 'some_topic' is not",
+					Range: hcl.Range{
+						Filename: "file.tf",
+						Start:    hcl.Pos{Line: 3, Column: 2},
+						End:      hcl.Pos{Line: 3, Column: 33},
+					},
+				},
+			},
+		},
+		{
+			name: "producing from topic not in module",
+			files: map[string]string{
+				"file.tf": `
+module "consumer" {
+	produce_topics = ["some_topic"]
+}
+`,
+			},
+			expected: []*helper.Issue{
+				{
+					Rule:    rule,
+					Message: "'produce_topics' may only contain topics defined in the current module but 'some_topic' is not",
+					Range: hcl.Range{
+						Filename: "file.tf",
+						Start:    hcl.Pos{Line: 3, Column: 2},
+						End:      hcl.Pos{Line: 3, Column: 33},
+					},
+				},
+			},
+		},
+		{
+			name: "producing and consuming from topic not in module",
+			files: map[string]string{
+				"file.tf": `
+module "consumer" {
+	consume_topics = ["some_topic"]
+	produce_topics = ["some_topic"]
+}
+`,
+			},
+			expected: []*helper.Issue{
+				{
+					Rule:    rule,
+					Message: "'consume_topics' may only contain topics defined in the current module but 'some_topic' is not",
+					Range: hcl.Range{
+						Filename: "file.tf",
+						Start:    hcl.Pos{Line: 3, Column: 2},
+						End:      hcl.Pos{Line: 3, Column: 33},
+					},
+				},
+				{
+					Rule:    rule,
+					Message: "'produce_topics' may only contain topics defined in the current module but 'some_topic' is not",
+					Range: hcl.Range{
+						Filename: "file.tf",
+						Start:    hcl.Pos{Line: 4, Column: 2},
+						End:      hcl.Pos{Line: 4, Column: 33},
+					},
+				},
+			},
+		},
+		{
+			name: "external topic defined outside of consumer/producer",
+			files: map[string]string{
+				"file.tf": `
+module "some_other_module" {
+	kafka_stuff = ["external_topic"]
+}
+`,
+			},
+			expected: []*helper.Issue{},
+		},
+		{
+			name: "all topics defined in file",
+			files: map[string]string{
+				"file.tf": `
+resource "kafka_topic" "first_topic" {
+	name = "first_topic"
+}
+
+resource "kafka_topic" "second_topic" {
+	name = "second_topic"
+}
+
+module "consumer" {
+	consume_topics = [kafka_topic.first_topic.name, kafka_topic.second_topic.name]
+	produce_topics = [kafka_topic.first_topic.name]
+}
+`,
+			},
+			expected: []*helper.Issue{},
+		},
+		{
+			name: "topics defined in separate file",
+			files: map[string]string{
+				"topics.tf": `
+resource "kafka_topic" "first_topic" {
+	name = "first_topic"
+}
+
+resource "kafka_topic" "second_topic" {
+	name = "second_topic"
+}
+`,
+				"file.tf": `
+module "consumer" {
+	consume_topics = [kafka_topic.first_topic.name, kafka_topic.second_topic.name]
+	produce_topics = [kafka_topic.first_topic.name]
+}
+`,
+			},
+			expected: []*helper.Issue{},
+		},
+		{
+			name: "topic name as string",
+			files: map[string]string{
+				"file.tf": `
+resource "kafka_topic" "first_topic" {
+	name = "my_topic"
+}
+
+module "consumer" {
+	consume_topics = ["my_topic"]
+}
+
+# other resources in the module should be ignored
+resource "some_resource" "some_other_resource" {
+}
+`,
+			},
+			expected: []*helper.Issue{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := helper.TestRunner(t, tc.files)
+
+			require.NoError(t, rule.Check(runner))
+
+			helper.AssertIssues(t, tc.expected, runner.Issues)
+		})
+	}
+}


### PR DESCRIPTION
This is rather tied to the expected implementation of defining consumes/producers using our `tls-app` module[1], specifically a `module` block that uses at least one of `consume_topics` or `produce_topics`.

`tflint` doesn't appear to do much (any) processing before running, so e.g.

* Doesn't populate bits following a `source = ./path/to/source`
* Doesn't do any variable expansion

A poke around of some existing linters gives the impression that the approach generally taken is just to skip running checks on these cases (e.g. [2] is a change is to a linter that runs on AWS resource tags, but just skips any tag that isn't a string literal. But, since almost all our produces/consumers are defined in blocks like:

    module "example_producer" {
      source           = "../../../modules/tls-app"
      produce_topics   = [kafka_topic.pubsub_examples.name]
      cert_common_name = "pubsub/example-producer"
    }

Simply skipping the variable name (`kafka_topic.pubsub_examples.name` in the example) would essentially mean the linter would skip every block. So the linter checks on `module`s of that structure.

Another approach I looked at was to use the `Expression.Variables`[3] and then try and build up a name from the parts of that, but I couldn't find a particularly clean way to do that.

[1] https://github.com/utilitywarehouse/kafka-cluster-config/tree/d28b50424f9d38d31ddceb50338df62a6934694f/modules/tls-app
[2] https://github.com/terraform-linters/tflint-ruleset-aws/commit/666253c1189a75fc3b8a46c5ed24cd59992a7e49
[3] https://pkg.go.dev/github.com/hashicorp/hcl/v2#Expression

Ticket: DENA-975