### PR TITLE
some tidying

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,10 +16,10 @@ func main() {
 			Name:    "uw-kafka-config",
 			Version: version,
 			Rules: []tflint.Rule{
-				rules.NewMskModuleBackendRule(),
-				&rules.MskAppTopics{},
-				&rules.MskTopicNameRule{},
-				&rules.MskTopicConfigRule{},
+				rules.NewMSKModuleBackendRule(),
+				&rules.MSKAppTopics{},
+				&rules.MSKTopicNameRule{},
+				&rules.MSKTopicConfigRule{},
 			},
 		},
 	})

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ func main() {
 			Name:    "uw-kafka-config",
 			Version: version,
 			Rules: []tflint.Rule{
-				rules.NewMSKModuleBackendRule(),
+				&rules.MSKModuleBackendRule{},
 				&rules.MSKAppTopics{},
 				&rules.MSKTopicNameRule{},
 				&rules.MSKTopicConfigRule{},

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ func main() {
 			Version: version,
 			Rules: []tflint.Rule{
 				&rules.MSKModuleBackendRule{},
-				&rules.MSKAppTopics{},
+				&rules.MSKAppTopicsRule{},
 				&rules.MSKTopicNameRule{},
 				&rules.MSKTopicConfigRule{},
 			},

--- a/rules/msk_app_topics.go
+++ b/rules/msk_app_topics.go
@@ -11,29 +11,29 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-// MSKAppTopics checks whether an MSK module only consumes from topics
+// MSKAppTopicsRule checks whether an MSK module only consumes from topics
 // defined in the module.
-type MSKAppTopics struct {
+type MSKAppTopicsRule struct {
 	tflint.DefaultRule
 }
 
-func (r *MSKAppTopics) Name() string {
+func (r *MSKAppTopicsRule) Name() string {
 	return "msk_app_topics"
 }
 
-func (r *MSKAppTopics) Enabled() bool {
+func (r *MSKAppTopicsRule) Enabled() bool {
 	return true
 }
 
-func (r *MSKAppTopics) Link() string {
+func (r *MSKAppTopicsRule) Link() string {
 	return ReferenceLink(r.Name())
 }
 
-func (r *MSKAppTopics) Severity() tflint.Severity {
+func (r *MSKAppTopicsRule) Severity() tflint.Severity {
 	return tflint.ERROR
 }
 
-func (r *MSKAppTopics) Check(runner tflint.Runner) error {
+func (r *MSKAppTopicsRule) Check(runner tflint.Runner) error {
 	isRoot, err := isRootModule(runner)
 	if err != nil {
 		return err
@@ -135,7 +135,7 @@ func buildTopicNameContext(topicNameMap map[string]string) *hcl.EvalContext {
 	}
 }
 
-func (r *MSKAppTopics) reportExternalTopics(
+func (r *MSKAppTopicsRule) reportExternalTopics(
 	runner tflint.Runner,
 	attrName string,
 	block *hclext.Block,

--- a/rules/msk_app_topics.go
+++ b/rules/msk_app_topics.go
@@ -34,11 +34,11 @@ func (r *MskAppTopics) Severity() tflint.Severity {
 }
 
 func (r *MskAppTopics) Check(runner tflint.Runner) error {
-	path, err := runner.GetModulePath()
+	isRoot, err := isRootModule(runner)
 	if err != nil {
-		return fmt.Errorf("getting module path: %w", err)
+		return err
 	}
-	if !path.IsRoot() {
+	if !isRoot {
 		logger.Debug("skipping child module")
 		return nil
 	}

--- a/rules/msk_app_topics.go
+++ b/rules/msk_app_topics.go
@@ -11,29 +11,29 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-// MskAppTopics checks whether an MSK module only consumes from topics
+// MSKAppTopics checks whether an MSK module only consumes from topics
 // defined in the module.
-type MskAppTopics struct {
+type MSKAppTopics struct {
 	tflint.DefaultRule
 }
 
-func (r *MskAppTopics) Name() string {
+func (r *MSKAppTopics) Name() string {
 	return "msk_app_topics"
 }
 
-func (r *MskAppTopics) Enabled() bool {
+func (r *MSKAppTopics) Enabled() bool {
 	return true
 }
 
-func (r *MskAppTopics) Link() string {
+func (r *MSKAppTopics) Link() string {
 	return ReferenceLink(r.Name())
 }
 
-func (r *MskAppTopics) Severity() tflint.Severity {
+func (r *MSKAppTopics) Severity() tflint.Severity {
 	return tflint.ERROR
 }
 
-func (r *MskAppTopics) Check(runner tflint.Runner) error {
+func (r *MSKAppTopics) Check(runner tflint.Runner) error {
 	isRoot, err := isRootModule(runner)
 	if err != nil {
 		return err
@@ -135,7 +135,7 @@ func buildTopicNameContext(topicNameMap map[string]string) *hcl.EvalContext {
 	}
 }
 
-func (r *MskAppTopics) reportExternalTopics(
+func (r *MSKAppTopics) reportExternalTopics(
 	runner tflint.Runner,
 	attrName string,
 	block *hclext.Block,

--- a/rules/msk_app_topics_test.go
+++ b/rules/msk_app_topics_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/terraform-linters/tflint-plugin-sdk/helper"
 )
 
-func Test_MskAppTopics(t *testing.T) {
-	rule := &MskAppTopics{}
+func Test_MSKAppTopics(t *testing.T) {
+	rule := &MSKAppTopics{}
 
 	for _, tc := range []struct {
 		name     string

--- a/rules/msk_app_topics_test.go
+++ b/rules/msk_app_topics_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/terraform-linters/tflint-plugin-sdk/helper"
 )
 
-func Test_MSKAppTopics(t *testing.T) {
-	rule := &MSKAppTopics{}
+func Test_MSKAppTopicsRule(t *testing.T) {
+	rule := &MSKAppTopicsRule{}
 
 	for _, tc := range []struct {
 		name     string

--- a/rules/msk_module_backend.go
+++ b/rules/msk_module_backend.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/logger"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )
 
@@ -69,12 +70,12 @@ func (r *MskModuleBackendRule) getBackendContent(runner tflint.Runner) (*hclext.
 }
 
 func (r *MskModuleBackendRule) Check(runner tflint.Runner) error {
-	path, err := runner.GetModulePath()
+	isRoot, err := isRootModule(runner)
 	if err != nil {
-		return fmt.Errorf("getting module path: %w", err)
+		return err
 	}
-	if !path.IsRoot() {
-		// This rule does not evaluate child modules.
+	if !isRoot {
+		logger.Debug("skipping child module")
 		return nil
 	}
 

--- a/rules/msk_module_backend.go
+++ b/rules/msk_module_backend.go
@@ -19,11 +19,6 @@ type MSKModuleBackendRule struct {
 	tflint.DefaultRule
 }
 
-// NewMSKModuleBackendRule returns a new rule.
-func NewMSKModuleBackendRule() *MSKModuleBackendRule {
-	return &MSKModuleBackendRule{}
-}
-
 // Name returns the rule name.
 func (r *MSKModuleBackendRule) Name() string {
 	return "msk_module_backend"

--- a/rules/msk_module_backend.go
+++ b/rules/msk_module_backend.go
@@ -12,39 +12,39 @@ import (
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )
 
-// MskModuleBackendRule checks whether an MSK module has an S3 backend defined with the following restrictions:
+// MSKModuleBackendRule checks whether an MSK module has an S3 backend defined with the following restrictions:
 //   - the key is in the format ${env}-${platform}/${msk-cluster}-${team-name}
 //   - the bucket contains the environment in its name
-type MskModuleBackendRule struct {
+type MSKModuleBackendRule struct {
 	tflint.DefaultRule
 }
 
-// NewMskModuleBackendRule returns a new rule.
-func NewMskModuleBackendRule() *MskModuleBackendRule {
-	return &MskModuleBackendRule{}
+// NewMSKModuleBackendRule returns a new rule.
+func NewMSKModuleBackendRule() *MSKModuleBackendRule {
+	return &MSKModuleBackendRule{}
 }
 
 // Name returns the rule name.
-func (r *MskModuleBackendRule) Name() string {
+func (r *MSKModuleBackendRule) Name() string {
 	return "msk_module_backend"
 }
 
 // Enabled returns whether the rule is enabled by default.
-func (r *MskModuleBackendRule) Enabled() bool {
+func (r *MSKModuleBackendRule) Enabled() bool {
 	return true
 }
 
 // Severity returns the rule severity.
-func (r *MskModuleBackendRule) Severity() tflint.Severity {
+func (r *MSKModuleBackendRule) Severity() tflint.Severity {
 	return tflint.ERROR
 }
 
 // Link returns the rule reference link.
-func (r *MskModuleBackendRule) Link() string {
+func (r *MSKModuleBackendRule) Link() string {
 	return ReferenceLink(r.Name())
 }
 
-func (r *MskModuleBackendRule) getBackendContent(runner tflint.Runner) (*hclext.BodyContent, error) {
+func (r *MSKModuleBackendRule) getBackendContent(runner tflint.Runner) (*hclext.BodyContent, error) {
 	//nolint:wrapcheck
 	return runner.GetModuleContent(&hclext.BodySchema{
 		Blocks: []hclext.BlockSchema{
@@ -69,7 +69,7 @@ func (r *MskModuleBackendRule) getBackendContent(runner tflint.Runner) (*hclext.
 	}, nil)
 }
 
-func (r *MskModuleBackendRule) Check(runner tflint.Runner) error {
+func (r *MSKModuleBackendRule) Check(runner tflint.Runner) error {
 	isRoot, err := isRootModule(runner)
 	if err != nil {
 		return err
@@ -106,7 +106,7 @@ func (r *MskModuleBackendRule) Check(runner tflint.Runner) error {
 	return r.checkBackendKeyFormat(runner, backend, *modInfo)
 }
 
-func (r *MskModuleBackendRule) validateBackendDef(
+func (r *MSKModuleBackendRule) validateBackendDef(
 	runner tflint.Runner,
 	content *hclext.BodyContent,
 ) (*hclext.Block, error) {
@@ -148,7 +148,7 @@ type moduleInfo struct {
 	mskCluster string
 }
 
-func (r *MskModuleBackendRule) checkBackendBucketFormat(
+func (r *MSKModuleBackendRule) checkBackendBucketFormat(
 	runner tflint.Runner,
 	backend *hclext.Block,
 	mi moduleInfo,
@@ -195,7 +195,7 @@ func (r *MskModuleBackendRule) checkBackendBucketFormat(
 	return nil
 }
 
-func (r *MskModuleBackendRule) checkBackendKeyFormat(runner tflint.Runner, backend *hclext.Block, mi moduleInfo) error {
+func (r *MSKModuleBackendRule) checkBackendKeyFormat(runner tflint.Runner, backend *hclext.Block, mi moduleInfo) error {
 	keyAttr, keyExists := backend.Body.Attributes["key"]
 	if !keyExists {
 		err := runner.EmitIssue(
@@ -235,7 +235,7 @@ func (r *MskModuleBackendRule) checkBackendKeyFormat(runner tflint.Runner, backe
 	return nil
 }
 
-func (r *MskModuleBackendRule) parseModuleInfo(runner tflint.Runner, backend *hclext.Block) (*moduleInfo, error) {
+func (r *MSKModuleBackendRule) parseModuleInfo(runner tflint.Runner, backend *hclext.Block) (*moduleInfo, error) {
 	modulePath, err := runner.GetOriginalwd()
 	if err != nil {
 		return nil, fmt.Errorf("failed getting module path: %w", err)

--- a/rules/msk_module_backend_test.go
+++ b/rules/msk_module_backend_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/terraform-linters/tflint-plugin-sdk/helper"
 )
 
-func Test_MskModuleBackend(t *testing.T) {
-	rule := NewMskModuleBackendRule()
+func Test_MSKModuleBackend(t *testing.T) {
+	rule := NewMSKModuleBackendRule()
 
 	defaultWorkDir := filepath.Join("kafka-cluster-config", "dev-aws", "kafka-shared-msk", "pubsub")
 

--- a/rules/msk_module_backend_test.go
+++ b/rules/msk_module_backend_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Test_MSKModuleBackend(t *testing.T) {
-	rule := NewMSKModuleBackendRule()
+	rule := &MSKModuleBackendRule{}
 
 	defaultWorkDir := filepath.Join("kafka-cluster-config", "dev-aws", "kafka-shared-msk", "pubsub")
 

--- a/rules/msk_topic_config.go
+++ b/rules/msk_topic_config.go
@@ -31,11 +31,11 @@ func (r *MskTopicConfigRule) Severity() tflint.Severity {
 }
 
 func (r *MskTopicConfigRule) Check(runner tflint.Runner) error {
-	path, err := runner.GetModulePath()
+	isRoot, err := isRootModule(runner)
 	if err != nil {
-		return fmt.Errorf("getting module path: %w", err)
+		return err
 	}
-	if !path.IsRoot() {
+	if !isRoot {
 		logger.Debug("skipping child module")
 		return nil
 	}

--- a/rules/msk_topic_config.go
+++ b/rules/msk_topic_config.go
@@ -9,28 +9,28 @@ import (
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )
 
-// MskTopicConfigRule checks the configuration for an MSK topic.
-type MskTopicConfigRule struct {
+// MSKTopicConfigRule checks the configuration for an MSK topic.
+type MSKTopicConfigRule struct {
 	tflint.DefaultRule
 }
 
-func (r *MskTopicConfigRule) Name() string {
+func (r *MSKTopicConfigRule) Name() string {
 	return "msk_topic_config"
 }
 
-func (r *MskTopicConfigRule) Enabled() bool {
+func (r *MSKTopicConfigRule) Enabled() bool {
 	return true
 }
 
-func (r *MskTopicConfigRule) Link() string {
+func (r *MSKTopicConfigRule) Link() string {
 	return ReferenceLink(r.Name())
 }
 
-func (r *MskTopicConfigRule) Severity() tflint.Severity {
+func (r *MSKTopicConfigRule) Severity() tflint.Severity {
 	return tflint.ERROR
 }
 
-func (r *MskTopicConfigRule) Check(runner tflint.Runner) error {
+func (r *MSKTopicConfigRule) Check(runner tflint.Runner) error {
 	isRoot, err := isRootModule(runner)
 	if err != nil {
 		return err
@@ -75,7 +75,7 @@ func (r *MskTopicConfigRule) Check(runner tflint.Runner) error {
 	return nil
 }
 
-func (r *MskTopicConfigRule) validateTopicConfig(runner tflint.Runner, topic *hclext.Block) error {
+func (r *MSKTopicConfigRule) validateTopicConfig(runner tflint.Runner, topic *hclext.Block) error {
 	if err := r.validateReplicationFactor(runner, topic); err != nil {
 		return err
 	}
@@ -91,7 +91,7 @@ const (
 
 var replFactorFix = fmt.Sprintf("%s = %d", replFactorAttrName, replicationFactorVal)
 
-func (r *MskTopicConfigRule) validateReplicationFactor(runner tflint.Runner, topic *hclext.Block) error {
+func (r *MSKTopicConfigRule) validateReplicationFactor(runner tflint.Runner, topic *hclext.Block) error {
 	replFactorAttr, hasReplFactor := topic.Body.Attributes[replFactorAttrName]
 	if !hasReplFactor {
 		return r.reportMissingReplicationFactor(runner, topic)
@@ -119,7 +119,7 @@ func (r *MskTopicConfigRule) validateReplicationFactor(runner tflint.Runner, top
 	return nil
 }
 
-func (r *MskTopicConfigRule) reportMissingReplicationFactor(runner tflint.Runner, topic *hclext.Block) error {
+func (r *MSKTopicConfigRule) reportMissingReplicationFactor(runner tflint.Runner, topic *hclext.Block) error {
 	nameAttr, hasName := topic.Body.Attributes["name"]
 	if !hasName {
 		/*	when no name attribute, we can not issue a fix, as we insert the replication factor after the name */

--- a/rules/msk_topic_config_test.go
+++ b/rules/msk_topic_config_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/terraform-linters/tflint-plugin-sdk/helper"
 )
 
-func Test_MskTopicConfigRule(t *testing.T) {
-	rule := &MskTopicConfigRule{}
+func Test_MSKTopicConfigRule(t *testing.T) {
+	rule := &MSKTopicConfigRule{}
 
 	const fileName = "topics.tf"
 	for _, tc := range []struct {

--- a/rules/msk_topic_name.go
+++ b/rules/msk_topic_name.go
@@ -37,11 +37,11 @@ func (r *MskTopicNameRule) Severity() tflint.Severity {
 }
 
 func (r *MskTopicNameRule) Check(runner tflint.Runner) error {
-	path, err := runner.GetModulePath()
+	isRoot, err := isRootModule(runner)
 	if err != nil {
-		return fmt.Errorf("getting module path: %w", err)
+		return err
 	}
-	if !path.IsRoot() {
+	if !isRoot {
 		logger.Debug("skipping child module")
 		return nil
 	}

--- a/rules/msk_topic_name.go
+++ b/rules/msk_topic_name.go
@@ -15,28 +15,28 @@ type mskTopicNameRuleConfig struct {
 	TeamAliases map[string][]string `hclext:"team_aliases,optional"`
 }
 
-// MskTopicNameRule checks whether a topic defined in MSK has an allowed team prefix.
-type MskTopicNameRule struct {
+// MSKTopicNameRule checks whether a topic defined in MSK has an allowed team prefix.
+type MSKTopicNameRule struct {
 	tflint.DefaultRule
 }
 
-func (r *MskTopicNameRule) Name() string {
+func (r *MSKTopicNameRule) Name() string {
 	return "msk_topic_name"
 }
 
-func (r *MskTopicNameRule) Enabled() bool {
+func (r *MSKTopicNameRule) Enabled() bool {
 	return true
 }
 
-func (r *MskTopicNameRule) Link() string {
+func (r *MSKTopicNameRule) Link() string {
 	return ReferenceLink(r.Name())
 }
 
-func (r *MskTopicNameRule) Severity() tflint.Severity {
+func (r *MSKTopicNameRule) Severity() tflint.Severity {
 	return tflint.ERROR
 }
 
-func (r *MskTopicNameRule) Check(runner tflint.Runner) error {
+func (r *MSKTopicNameRule) Check(runner tflint.Runner) error {
 	isRoot, err := isRootModule(runner)
 	if err != nil {
 		return err
@@ -80,7 +80,7 @@ func (r *MskTopicNameRule) Check(runner tflint.Runner) error {
 	return nil
 }
 
-func (r *MskTopicNameRule) validateTopicName(
+func (r *MSKTopicNameRule) validateTopicName(
 	runner tflint.Runner,
 	topic *hclext.Block,
 	teamName string,

--- a/rules/msk_topic_name_test.go
+++ b/rules/msk_topic_name_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/terraform-linters/tflint-plugin-sdk/helper"
 )
 
-func Test_MskTopics(t *testing.T) {
-	rule := &MskTopicNameRule{}
+func Test_MSKTopics(t *testing.T) {
+	rule := &MSKTopicNameRule{}
 
 	for _, tc := range []struct {
 		name     string

--- a/rules/util.go
+++ b/rules/util.go
@@ -1,7 +1,23 @@
 package rules
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
 
 func ReferenceLink(name string) string {
 	return fmt.Sprintf("https://github.com/utilitywarehouse/tflint-ruleset-kafka-config/blob/main/rules/%s.md", name)
+}
+
+// many of our rules want to look at a root module and collect information
+// about all its child modules. Hence they only want to run for root modules
+// and not be also invoked on each child module.
+func isRootModule(runner tflint.Runner) (bool, error) {
+	path, err := runner.GetModulePath()
+	if err != nil {
+		return false, fmt.Errorf("getting module path: %w", err)
+	}
+
+	return path.IsRoot(), nil
 }


### PR DESCRIPTION
- Add util for checking if module is root

    I was hoping to save some lines of code by adding a 'skipIfNotRoot`
    func, but the runner doesn't really have any functionality for this, so
    the helper is just to move some logic to one place rather than have it
    copied around.

- Rename all rules: `Msk` -> `MSK`

    Since this is an acronym. This shouldn't change anything for users,
    since plugins are reference by their `.Name()` in configs.

- Remove unnecessary constructor func

    For the sake of consistency with other rules

- Add 'Rule' suffix to topics rule

    To be consistent with all the other types