### PR TITLE
DENA-671: Validate cleanup policy

### DIFF
--- a/rules/msk_topic_config.go
+++ b/rules/msk_topic_config.go
@@ -96,7 +96,7 @@ func (r *MSKTopicConfigRule) validateTopicConfig(runner tflint.Runner, topic *hc
 		return err
 	}
 
-	if err := r.ValidateCleanupPolicy(runner, configAttr, configKeyToPairMap); err != nil {
+	if err := r.validateCleanupPolicy(runner, configAttr, configKeyToPairMap); err != nil {
 		return err
 	}
 	return nil
@@ -246,7 +246,7 @@ var (
 	cleanupPolicyValidValues = []string{"delete", "compact"}
 )
 
-func (r *MSKTopicConfigRule) ValidateCleanupPolicy(
+func (r *MSKTopicConfigRule) validateCleanupPolicy(
 	runner tflint.Runner,
 	config *hclext.Attribute,
 	configKeyToPairMap map[string]hcl.KeyValuePair,

--- a/rules/msk_topic_config.md
+++ b/rules/msk_topic_config.md
@@ -5,6 +5,7 @@
 An MSK topic configuration must comply with the following rules:
 - the replication factor must be equal to 3, because we are deploying across 3 availability zones and this is the minimum we can run, since min-in-sync replicas is set to 2. 
 - the 'compression.type' must always be set to `zstd`. This is a very good compression algorithm, and it is set by default for the producer in our [kafka lib](https://github.com/utilitywarehouse/uwos-go/tree/main/pubsub/kafka)
+- the 'cleanup.policy' must be specified and must be one of 'delete' or 'compact'. If not specified, it is set automatically on 'delete'. See [kafka spec](https://kafka.apache.org/30/generated/topic_config.html#topicconfigs_cleanup.policy)
 
 ## Example
 
@@ -16,6 +17,7 @@ resource "kafka_topic" "good_topic" {
   replication_factor = 3
   config = {
     "compression.type" = "zstd"
+    "cleanup.policy"   = "delete"
   }
 }
 
@@ -34,6 +36,14 @@ resource "kafka_topic" "topic_with_wrong_compression_type" {
   name = "wrong-topic"
   config = {
     "compression.type" = "gzip"
+  }
+}
+
+# topic with cleanup policy
+resource "kafka_topic" "topic_with_wrong_cleanup_policy" {
+  name = "wrong-topic"
+  config = {
+    "cleanup.policy" = "invalid-value"
   }
 }
 ```


### PR DESCRIPTION
This will make some changes in kafka-cluster-config, as not all topics define the cleanup policy, but rely on the default one