### PR TITLE
DENA-671: wrong compression type: put the issue on the value, rather than the key

### DIFF
--- a/rules/msk_topic_config.go
+++ b/rules/msk_topic_config.go
@@ -223,7 +223,7 @@ func (r *MSKTopicConfigRule) validateCompressionType(
 		err := runner.EmitIssueWithFix(
 			r,
 			fmt.Sprintf("the %s value must be equal to '%s'", compressionTypeKey, compressionTypeVal),
-			ctPair.Key.Range(),
+			ctPair.Value.Range(),
 			func(f tflint.Fixer) error {
 				return f.ReplaceText(ctPair.Value.Range(), `"`+compressionTypeVal+`"`)
 			},

--- a/rules/msk_topic_config_test.go
+++ b/rules/msk_topic_config_test.go
@@ -180,8 +180,8 @@ resource "kafka_topic" "topic_with_wrong_compression_type" {
 					Message: "the compression.type value must be equal to 'zstd'",
 					Range: hcl.Range{
 						Filename: fileName,
-						Start:    hcl.Pos{Line: 7, Column: 5},
-						End:      hcl.Pos{Line: 7, Column: 23},
+						Start:    hcl.Pos{Line: 7, Column: 26},
+						End:      hcl.Pos{Line: 7, Column: 32},
 					},
 				},
 			},


### PR DESCRIPTION
Change where we report the issue when compression type is invalid