### PR TITLE
DENA-671: validate tiered storage

### DIFF
--- a/rules/msk_topic_config.go
+++ b/rules/msk_topic_config.go
@@ -395,8 +395,8 @@ func (r *MSKTopicConfigRule) validateLocalRetentionSpecified(
 	return nil
 }
 
-func isInfiniteRetention(rtIntVal int) bool {
-	return rtIntVal < 0
+func isInfiniteRetention(val int) bool {
+	return val < 0
 }
 
 func (r *MSKTopicConfigRule) validateTieredStorageEnabled(

--- a/rules/msk_topic_config.go
+++ b/rules/msk_topic_config.go
@@ -372,7 +372,7 @@ func (r *MSKTopicConfigRule) validateTieredStorageEnabled(
 	tieredStoragePair, hasTieredStorageAttr := configKeyToPairMap[tieredStorageEnableAttr]
 	if !hasTieredStorageAttr {
 		msg := fmt.Sprintf(
-			"tiered storage should be enabled when retention time is higher than %d days",
+			"tiered storage should be enabled when retention time is longer than %d days",
 			tieredStorageThresholdInDays,
 		)
 		err := runner.EmitIssueWithFix(r, msg, config.Range,
@@ -394,7 +394,7 @@ func (r *MSKTopicConfigRule) validateTieredStorageEnabled(
 
 	if tieredStorageVal != tieredStorageEnabledValue {
 		msg := fmt.Sprintf(
-			"tiered storage should be enabled when retention time is higher than %d days",
+			"tiered storage should be enabled when retention time is longer than %d days",
 			tieredStorageThresholdInDays,
 		)
 		err := runner.EmitIssueWithFix(r, msg, tieredStoragePair.Value.Range(),

--- a/rules/msk_topic_config.go
+++ b/rules/msk_topic_config.go
@@ -340,11 +340,21 @@ func (r *MSKTopicConfigRule) validateRetentionForDeletePolicy(
 		return nil
 	}
 
-	err = r.validateTieredStorageEnabled(runner, config, configKeyToPairMap)
-	if err != nil {
+	if err := r.validateTieredStorageEnabled(runner, config, configKeyToPairMap); err != nil {
 		return err
 	}
 
+	if err := r.validateLocalRetentionSpecified(runner, config, configKeyToPairMap); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *MSKTopicConfigRule) validateLocalRetentionSpecified(
+	runner tflint.Runner,
+	config *hclext.Attribute,
+	configKeyToPairMap map[string]hcl.KeyValuePair,
+) error {
 	_, hasLocalRetTimeAttr := configKeyToPairMap[localRetentionTimeAttr]
 	if !hasLocalRetTimeAttr {
 		msg := fmt.Sprintf(
@@ -360,7 +370,9 @@ func (r *MSKTopicConfigRule) validateRetentionForDeletePolicy(
 		if err != nil {
 			return fmt.Errorf("emitting issue: remote storage enable: %w", err)
 		}
+		return nil
 	}
+
 	return nil
 }
 

--- a/rules/msk_topic_config.go
+++ b/rules/msk_topic_config.go
@@ -332,8 +332,12 @@ func (r *MSKTopicConfigRule) validateRetentionForDeletePolicy(
 	configKeyToPairMap map[string]hcl.KeyValuePair,
 ) error {
 	retentionTime, err := r.getAndValidateRetentionTime(runner, config, configKeyToPairMap)
-	if err != nil || retentionTime == nil {
+	if err != nil {
 		return err
+	}
+
+	if retentionTime == nil {
+		return nil
 	}
 
 	if *retentionTime <= tieredStorageThresholdInDays*millisInOneDay && !isInfiniteRetention(*retentionTime) {
@@ -406,7 +410,7 @@ func (r *MSKTopicConfigRule) validateTieredStorageEnabled(
 ) error {
 	tieredStoragePair, hasTieredStorageAttr := configKeyToPairMap[tieredStorageEnableAttr]
 	tieredStorageEnableMsg := fmt.Sprintf(
-		"tiered storage should be enabled when retention time is longer than %d days",
+		"tiered storage must be enabled when retention time is longer than %d days",
 		tieredStorageThresholdInDays,
 	)
 

--- a/rules/msk_topic_config.go
+++ b/rules/msk_topic_config.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -96,8 +97,17 @@ func (r *MSKTopicConfigRule) validateTopicConfig(runner tflint.Runner, topic *hc
 		return err
 	}
 
-	if err := r.validateCleanupPolicy(runner, configAttr, configKeyToPairMap); err != nil {
+	cleanupPolicy, err := r.validateCleanupPolicy(runner, configAttr, configKeyToPairMap)
+	if err != nil {
 		return err
+	}
+	switch cleanupPolicy {
+	case cleanupPolicyDelete:
+		if err := r.validateRetentionForDeletePolicy(runner, configAttr, configKeyToPairMap); err != nil {
+			return err
+		}
+	case cleanupPolicyCompact:
+		// todo: validate no retention & remote storage for compact
 	}
 	return nil
 }
@@ -238,19 +248,21 @@ func (r *MSKTopicConfigRule) validateCompressionType(
 
 const (
 	cleanupPolicyKey     = "cleanup.policy"
-	cleanupPolicyDefault = "delete"
+	cleanupPolicyDelete  = "delete"
+	cleanupPolicyCompact = "compact"
+	cleanupPolicyDefault = cleanupPolicyDelete
 )
 
 var (
 	cleanupPolicyDefaultFix  = fmt.Sprintf(`"%s" = "%s"`, cleanupPolicyKey, cleanupPolicyDefault)
-	cleanupPolicyValidValues = []string{"delete", "compact"}
+	cleanupPolicyValidValues = []string{cleanupPolicyDelete, cleanupPolicyCompact}
 )
 
 func (r *MSKTopicConfigRule) validateCleanupPolicy(
 	runner tflint.Runner,
 	config *hclext.Attribute,
 	configKeyToPairMap map[string]hcl.KeyValuePair,
-) error {
+) (string, error) {
 	cpPair, hasCp := configKeyToPairMap[cleanupPolicyKey]
 	if !hasCp {
 		err := runner.EmitIssueWithFix(
@@ -262,15 +274,15 @@ func (r *MSKTopicConfigRule) validateCleanupPolicy(
 			},
 		)
 		if err != nil {
-			return fmt.Errorf("emitting issue with fix: no cleanup policy: %w", err)
+			return "", fmt.Errorf("emitting issue with fix: no cleanup policy: %w", err)
 		}
-		return nil
+		return cleanupPolicyDefault, nil
 	}
 
 	var cpVal string
 	diags := gohcl.DecodeExpression(cpPair.Value, nil, &cpVal)
 	if diags.HasErrors() {
-		return diags
+		return "", diags
 	}
 	if !slices.Contains(cleanupPolicyValidValues, cpVal) {
 		err := runner.EmitIssue(
@@ -284,7 +296,59 @@ func (r *MSKTopicConfigRule) validateCleanupPolicy(
 			cpPair.Value.Range(),
 		)
 		if err != nil {
-			return fmt.Errorf("emitting issue: invalid cleanup policy: %w", err)
+			return "", fmt.Errorf("emitting issue: invalid cleanup policy: %w", err)
+		}
+		return "", nil
+	}
+	return cpVal, nil
+}
+
+const (
+	retentionTimeAttr = "retention.ms"
+)
+
+/*	Putting an invalid value by default to force users to put a valid value */
+var retentionTimeDefTemplate = fmt.Sprintf(`"%s" = "???"`, retentionTimeAttr)
+
+func (r *MSKTopicConfigRule) validateRetentionForDeletePolicy(
+	runner tflint.Runner,
+	config *hclext.Attribute,
+	configKeyToPairMap map[string]hcl.KeyValuePair,
+) error {
+	rtPair, hasRt := configKeyToPairMap[retentionTimeAttr]
+	if !hasRt {
+		err := runner.EmitIssueWithFix(
+			r,
+			fmt.Sprintf("%s must be defined on a topic with cleanup policy delete", retentionTimeAttr),
+			config.Range,
+			func(f tflint.Fixer) error {
+				return f.InsertTextAfter(config.Expr.StartRange(), "\n"+retentionTimeDefTemplate)
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("emitting issue: no retention time: %w", err)
+		}
+		return nil
+	}
+
+	var rtVal string
+	diags := gohcl.DecodeExpression(rtPair.Value, nil, &rtVal)
+	if diags.HasErrors() {
+		return diags
+	}
+
+	_, err := strconv.Atoi(rtVal)
+	if err != nil {
+		err := runner.EmitIssue(
+			r,
+			fmt.Sprintf(
+				"%s must have a valid integer value expressed in milliseconds. Use -1 for infinite retention",
+				retentionTimeAttr,
+			),
+			rtPair.Value.Range(),
+		)
+		if err != nil {
+			return fmt.Errorf("emitting issue: invalid retention time: %w", err)
 		}
 		return nil
 	}

--- a/rules/msk_topic_config.go
+++ b/rules/msk_topic_config.go
@@ -317,10 +317,8 @@ func (r *MSKTopicConfigRule) validateRetentionForDeletePolicy(
 ) error {
 	rtPair, hasRt := configKeyToPairMap[retentionTimeAttr]
 	if !hasRt {
-		err := runner.EmitIssueWithFix(
-			r,
-			fmt.Sprintf("%s must be defined on a topic with cleanup policy delete", retentionTimeAttr),
-			config.Range,
+		msg := fmt.Sprintf("%s must be defined on a topic with cleanup policy delete", retentionTimeAttr)
+		err := runner.EmitIssueWithFix(r, msg, config.Range,
 			func(f tflint.Fixer) error {
 				return f.InsertTextAfter(config.Expr.StartRange(), "\n"+retentionTimeDefTemplate)
 			},
@@ -339,18 +337,16 @@ func (r *MSKTopicConfigRule) validateRetentionForDeletePolicy(
 
 	_, err := strconv.Atoi(rtVal)
 	if err != nil {
-		err := runner.EmitIssue(
-			r,
-			fmt.Sprintf(
-				"%s must have a valid integer value expressed in milliseconds. Use -1 for infinite retention",
-				retentionTimeAttr,
-			),
-			rtPair.Value.Range(),
+		msg := fmt.Sprintf(
+			"%s must have a valid integer value expressed in milliseconds. Use -1 for infinite retention",
+			retentionTimeAttr,
 		)
+		err := runner.EmitIssue(r, msg, rtPair.Value.Range())
 		if err != nil {
 			return fmt.Errorf("emitting issue: invalid retention time: %w", err)
 		}
 		return nil
 	}
+
 	return nil
 }

--- a/rules/msk_topic_config.go
+++ b/rules/msk_topic_config.go
@@ -374,12 +374,13 @@ func (r *MSKTopicConfigRule) validateTieredStorageEnabled(
 	configKeyToPairMap map[string]hcl.KeyValuePair,
 ) error {
 	tieredStoragePair, hasTieredStorageAttr := configKeyToPairMap[tieredStorageEnableAttr]
+	tieredStorageEnableMsg := fmt.Sprintf(
+		"tiered storage should be enabled when retention time is longer than %d days",
+		tieredStorageThresholdInDays,
+	)
+
 	if !hasTieredStorageAttr {
-		msg := fmt.Sprintf(
-			"tiered storage should be enabled when retention time is longer than %d days",
-			tieredStorageThresholdInDays,
-		)
-		err := runner.EmitIssueWithFix(r, msg, config.Range,
+		err := runner.EmitIssueWithFix(r, tieredStorageEnableMsg, config.Range,
 			func(f tflint.Fixer) error {
 				return f.InsertTextAfter(config.Expr.StartRange(), "\n"+enableTieredStorage)
 			},
@@ -397,11 +398,7 @@ func (r *MSKTopicConfigRule) validateTieredStorageEnabled(
 	}
 
 	if tieredStorageVal != tieredStorageEnabledValue {
-		msg := fmt.Sprintf(
-			"tiered storage should be enabled when retention time is longer than %d days",
-			tieredStorageThresholdInDays,
-		)
-		err := runner.EmitIssueWithFix(r, msg, tieredStoragePair.Value.Range(),
+		err := runner.EmitIssueWithFix(r, tieredStorageEnableMsg, tieredStoragePair.Value.Range(),
 			func(f tflint.Fixer) error {
 				return f.ReplaceText(tieredStoragePair.Value.Range(), fmt.Sprintf(`"%s"`, tieredStorageEnabledValue))
 			},

--- a/rules/msk_topic_config.go
+++ b/rules/msk_topic_config.go
@@ -336,7 +336,7 @@ func (r *MSKTopicConfigRule) validateRetentionForDeletePolicy(
 		return err
 	}
 
-	if *rtIntVal <= tieredStorageThresholdInDays*millisInOneDay {
+	if *rtIntVal <= tieredStorageThresholdInDays*millisInOneDay && !isInfiniteRetention(*rtIntVal) {
 		return nil
 	}
 
@@ -362,6 +362,10 @@ func (r *MSKTopicConfigRule) validateRetentionForDeletePolicy(
 		}
 	}
 	return nil
+}
+
+func isInfiniteRetention(rtIntVal int) bool {
+	return rtIntVal < 0
 }
 
 func (r *MSKTopicConfigRule) validateTieredStorageEnabled(

--- a/rules/msk_topic_config.go
+++ b/rules/msk_topic_config.go
@@ -97,7 +97,7 @@ func (r *MSKTopicConfigRule) validateTopicConfig(runner tflint.Runner, topic *hc
 		return err
 	}
 
-	cleanupPolicy, err := r.gateAndValidateCleanupPolicy(runner, configAttr, configKeyToPairMap)
+	cleanupPolicy, err := r.getAndValidateCleanupPolicy(runner, configAttr, configKeyToPairMap)
 	if err != nil {
 		return err
 	}
@@ -258,7 +258,7 @@ var (
 	cleanupPolicyValidValues = []string{cleanupPolicyDelete, cleanupPolicyCompact}
 )
 
-func (r *MSKTopicConfigRule) gateAndValidateCleanupPolicy(
+func (r *MSKTopicConfigRule) getAndValidateCleanupPolicy(
 	runner tflint.Runner,
 	config *hclext.Attribute,
 	configKeyToPairMap map[string]hcl.KeyValuePair,

--- a/rules/msk_topic_config.go
+++ b/rules/msk_topic_config.go
@@ -336,7 +336,7 @@ func (r *MSKTopicConfigRule) validateRetentionForDeletePolicy(
 		return err
 	}
 
-	if *rtIntVal < tieredStorageThresholdInDays*millisInOneDay {
+	if *rtIntVal <= tieredStorageThresholdInDays*millisInOneDay {
 		return nil
 	}
 

--- a/rules/msk_topic_config.go
+++ b/rules/msk_topic_config.go
@@ -97,7 +97,7 @@ func (r *MSKTopicConfigRule) validateTopicConfig(runner tflint.Runner, topic *hc
 		return err
 	}
 
-	cleanupPolicy, err := r.validateCleanupPolicy(runner, configAttr, configKeyToPairMap)
+	cleanupPolicy, err := r.gateAndValidateCleanupPolicy(runner, configAttr, configKeyToPairMap)
 	if err != nil {
 		return err
 	}
@@ -258,7 +258,7 @@ var (
 	cleanupPolicyValidValues = []string{cleanupPolicyDelete, cleanupPolicyCompact}
 )
 
-func (r *MSKTopicConfigRule) validateCleanupPolicy(
+func (r *MSKTopicConfigRule) gateAndValidateCleanupPolicy(
 	runner tflint.Runner,
 	config *hclext.Attribute,
 	configKeyToPairMap map[string]hcl.KeyValuePair,

--- a/rules/msk_topic_config_test.go
+++ b/rules/msk_topic_config_test.go
@@ -379,7 +379,7 @@ resource "kafka_topic" "topic_with_more_than_3_days_retention" {
 			expected: []*helper.Issue{
 				{
 					Rule:    rule,
-					Message: "tiered storage should be enabled when retention time is higher than 3 days",
+					Message: "tiered storage should be enabled when retention time is longer than 3 days",
 					Range: hcl.Range{
 						Filename: fileName,
 						Start:    hcl.Pos{Line: 5, Column: 3},
@@ -427,7 +427,7 @@ resource "kafka_topic" "topic_with_missing_tiered_storage_enabling" {
 			expected: []*helper.Issue{
 				{
 					Rule:    rule,
-					Message: "tiered storage should be enabled when retention time is higher than 3 days",
+					Message: "tiered storage should be enabled when retention time is longer than 3 days",
 					Range: hcl.Range{
 						Filename: fileName,
 						Start:    hcl.Pos{Line: 5, Column: 3},
@@ -465,7 +465,7 @@ resource "kafka_topic" "topic_with_more_than_3_days_retention_tiered_disabled" {
 			expected: []*helper.Issue{
 				{
 					Rule:    rule,
-					Message: "tiered storage should be enabled when retention time is higher than 3 days",
+					Message: "tiered storage should be enabled when retention time is longer than 3 days",
 					Range: hcl.Range{
 						Filename: fileName,
 						Start:    hcl.Pos{Line: 6, Column: 31},

--- a/rules/msk_topic_config_test.go
+++ b/rules/msk_topic_config_test.go
@@ -484,7 +484,7 @@ resource "kafka_topic" "topic_with_more_than_3_days_retention_tiered_disabled" {
 			},
 		},
 		{
-			name: "good topic definition",
+			name: "good topic definition without retention",
 			input: `
 resource "kafka_topic" "good topic" {
   name               = "good_topic"
@@ -493,6 +493,23 @@ resource "kafka_topic" "good topic" {
     "cleanup.policy"   = "delete"
     "compression.type" = "zstd"
     "retention.ms"     = "86400000"
+  }
+}`,
+			expected: []*helper.Issue{},
+		},
+		{
+			name: "good topic definition with retention",
+			input: `
+resource "kafka_topic" "good topic" {
+  name               = "good_topic"
+  replication_factor = 3
+  config = {
+    # keep data in hot storage for 1 day
+    "local.retention.ms"    = "86400000"
+    "remote.storage.enable" = "true"
+    "cleanup.policy"        = "delete"
+    "retention.ms"          = "2592000000"
+    "compression.type"      = "zstd"
   }
 }`,
 			expected: []*helper.Issue{},

--- a/rules/msk_topic_config_test.go
+++ b/rules/msk_topic_config_test.go
@@ -352,7 +352,7 @@ resource "kafka_topic" "topic_with_invalid_retention" {
 			},
 		},
 		{
-			name: "retention time bigger than 3 days requires tiered storage",
+			name: "retention time longer than 3 days requires tiered storage",
 			input: `
 resource "kafka_topic" "topic_with_more_than_3_days_retention" {
   name               = "topic_with_more_than_3_days_retention"

--- a/rules/msk_topic_config_test.go
+++ b/rules/msk_topic_config_test.go
@@ -398,6 +398,52 @@ resource "kafka_topic" "topic_with_more_than_3_days_retention" {
 			},
 		},
 		{
+			name: "infinite retention time requires tiered storage",
+			input: `
+resource "kafka_topic" "topic_with_infinite_retention" {
+  name               = "topic_with_infinite_retention"
+  replication_factor = 3
+  config = {
+    "cleanup.policy"   = "delete"
+    "retention.ms"     = "-1"
+    "compression.type" = "zstd"
+  }
+}`,
+			fixed: `
+resource "kafka_topic" "topic_with_infinite_retention" {
+  name               = "topic_with_infinite_retention"
+  replication_factor = 3
+  config = {
+    "remote.storage.enable" = "true"
+    # keep data in hot storage for 1 day
+    "local.retention.ms" = "86400000"
+    "cleanup.policy"     = "delete"
+    "retention.ms"       = "-1"
+    "compression.type"   = "zstd"
+  }
+}`,
+			expected: []*helper.Issue{
+				{
+					Rule:    rule,
+					Message: "tiered storage should be enabled when retention time is longer than 3 days",
+					Range: hcl.Range{
+						Filename: fileName,
+						Start:    hcl.Pos{Line: 5, Column: 3},
+						End:      hcl.Pos{Line: 9, Column: 4},
+					},
+				},
+				{
+					Rule:    rule,
+					Message: "missing local.retention.ms when tiered storage is enabled: using default '86400000'",
+					Range: hcl.Range{
+						Filename: fileName,
+						Start:    hcl.Pos{Line: 5, Column: 3},
+						End:      hcl.Pos{Line: 9, Column: 4},
+					},
+				},
+			},
+		},
+		{
 			name: "forgot tiered storage enabling",
 			input: `
 resource "kafka_topic" "topic_with_missing_tiered_storage_enabling" {

--- a/rules/msk_topic_config_test.go
+++ b/rules/msk_topic_config_test.go
@@ -379,7 +379,7 @@ resource "kafka_topic" "topic_with_more_than_3_days_retention" {
 			expected: []*helper.Issue{
 				{
 					Rule:    rule,
-					Message: "tiered storage should be enabled when retention time is longer than 3 days",
+					Message: "tiered storage must be enabled when retention time is longer than 3 days",
 					Range: hcl.Range{
 						Filename: fileName,
 						Start:    hcl.Pos{Line: 5, Column: 3},
@@ -425,7 +425,7 @@ resource "kafka_topic" "topic_with_infinite_retention" {
 			expected: []*helper.Issue{
 				{
 					Rule:    rule,
-					Message: "tiered storage should be enabled when retention time is longer than 3 days",
+					Message: "tiered storage must be enabled when retention time is longer than 3 days",
 					Range: hcl.Range{
 						Filename: fileName,
 						Start:    hcl.Pos{Line: 5, Column: 3},
@@ -473,7 +473,7 @@ resource "kafka_topic" "topic_with_missing_tiered_storage_enabling" {
 			expected: []*helper.Issue{
 				{
 					Rule:    rule,
-					Message: "tiered storage should be enabled when retention time is longer than 3 days",
+					Message: "tiered storage must be enabled when retention time is longer than 3 days",
 					Range: hcl.Range{
 						Filename: fileName,
 						Start:    hcl.Pos{Line: 5, Column: 3},
@@ -511,7 +511,7 @@ resource "kafka_topic" "topic_with_more_than_3_days_retention_tiered_disabled" {
 			expected: []*helper.Issue{
 				{
 					Rule:    rule,
-					Message: "tiered storage should be enabled when retention time is longer than 3 days",
+					Message: "tiered storage must be enabled when retention time is longer than 3 days",
 					Range: hcl.Range{
 						Filename: fileName,
 						Start:    hcl.Pos{Line: 6, Column: 31},

--- a/rules/msk_topic_config_test.go
+++ b/rules/msk_topic_config_test.go
@@ -359,7 +359,7 @@ resource "kafka_topic" "topic_with_more_than_3_days_retention" {
   replication_factor = 3
   config = {
     "cleanup.policy"   = "delete"
-    "retention.ms"     = "259200000"
+    "retention.ms"     = "259200001"
     "compression.type" = "zstd"
   }
 }`,
@@ -372,7 +372,7 @@ resource "kafka_topic" "topic_with_more_than_3_days_retention" {
     # keep data in hot storage for 1 day
     "local.retention.ms" = "86400000"
     "cleanup.policy"     = "delete"
-    "retention.ms"       = "259200000"
+    "retention.ms"       = "259200001"
     "compression.type"   = "zstd"
   }
 }`,
@@ -406,7 +406,7 @@ resource "kafka_topic" "topic_with_more_than_3_days_retention_tiered_disabled" {
   config = {
     "remote.storage.enable" = "false"
     "cleanup.policy"        = "delete"
-    "retention.ms"          = "259200000"
+    "retention.ms"          = "259200001"
     "compression.type"      = "zstd"
   }
 }`,
@@ -419,7 +419,7 @@ resource "kafka_topic" "topic_with_more_than_3_days_retention_tiered_disabled" {
     "local.retention.ms"    = "86400000"
     "remote.storage.enable" = "true"
     "cleanup.policy"        = "delete"
-    "retention.ms"          = "259200000"
+    "retention.ms"          = "259200001"
     "compression.type"      = "zstd"
   }
 }`,

--- a/rules/msk_topic_config_test.go
+++ b/rules/msk_topic_config_test.go
@@ -568,6 +568,32 @@ resource "kafka_topic" "topic_with_tiered_storage_missing_local_retention" {
 			},
 		},
 		{
+			name: "tiered storage enabled and local retention invalid",
+			input: `
+resource "kafka_topic" "topic_with_tiered_storage_local_retention_invalid" {
+  name               = "topic_with_tiered_storage_local_retention_invalid"
+  replication_factor = 3
+  config = {
+    "remote.storage.enable" = "true"
+    "cleanup.policy"        = "delete"
+    "retention.ms"          = "259200001"
+    "local.retention.ms"    = "invalid-val"
+    "compression.type"      = "zstd"
+  }
+}`,
+			expected: []*helper.Issue{
+				{
+					Rule:    rule,
+					Message: "local.retention.ms must have a valid integer value expressed in milliseconds",
+					Range: hcl.Range{
+						Filename: fileName,
+						Start:    hcl.Pos{Line: 9, Column: 31},
+						End:      hcl.Pos{Line: 9, Column: 44},
+					},
+				},
+			},
+		},
+		{
 			name: "good topic definition without retention",
 			input: `
 resource "kafka_topic" "good topic" {


### PR DESCRIPTION
Added validations for tiered storage:
- for a retention period longer than 3 days enable tiered storage & the local.retention.ms is specified

I'd like to do a new release after this, as this is the most common & complex validation that we're doing
