### PR TITLE
DENA-671: Tiered storage enabled for 3 days inclusive

### DIFF
--- a/rules/msk_topic_config.go
+++ b/rules/msk_topic_config.go
@@ -340,7 +340,7 @@ func (r *MSKTopicConfigRule) validateRetentionForDeletePolicy(
 		return nil
 	}
 
-	if *retentionTime <= tieredStorageThresholdInDays*millisInOneDay && !isInfiniteRetention(*retentionTime) {
+	if !mustEnableTieredStorage(*retentionTime) {
 		return nil
 	}
 
@@ -352,6 +352,10 @@ func (r *MSKTopicConfigRule) validateRetentionForDeletePolicy(
 		return err
 	}
 	return nil
+}
+
+func mustEnableTieredStorage(retentionTime int) bool {
+	return retentionTime >= tieredStorageThresholdInDays*millisInOneDay || isInfiniteRetention(retentionTime)
 }
 
 func (r *MSKTopicConfigRule) validateLocalRetentionSpecified(

--- a/rules/msk_topic_config.md
+++ b/rules/msk_topic_config.md
@@ -9,7 +9,7 @@ An MSK topic configuration must comply with the following rules:
 
 When cleanup policy is 'delete': 
 - 'retention.ms' must be specified in the config map with a valid int value expressed in milliseconds
-- for a retention period longer than 3 days, tiered storage must be enabled and the local.retention.ms must be specified
+- for a retention period of 3 days or more, tiered storage must be enabled and the local.retention.ms parameter must be defined
 
 ## Example
 

--- a/rules/msk_topic_config_test.go
+++ b/rules/msk_topic_config_test.go
@@ -352,14 +352,14 @@ resource "kafka_topic" "topic_with_invalid_retention" {
 			},
 		},
 		{
-			name: "retention time longer than 3 days requires tiered storage",
+			name: "retention time of 3 days requires tiered storage",
 			input: `
 resource "kafka_topic" "topic_with_more_than_3_days_retention" {
   name               = "topic_with_more_than_3_days_retention"
   replication_factor = 3
   config = {
     "cleanup.policy"   = "delete"
-    "retention.ms"     = "259200001"
+    "retention.ms"     = "259200000"
     "compression.type" = "zstd"
   }
 }`,
@@ -372,7 +372,7 @@ resource "kafka_topic" "topic_with_more_than_3_days_retention" {
     # keep data in hot storage for 1 day
     "local.retention.ms" = "86400000"
     "cleanup.policy"     = "delete"
-    "retention.ms"       = "259200001"
+    "retention.ms"       = "259200000"
     "compression.type"   = "zstd"
   }
 }`,


### PR DESCRIPTION
Realised that some of the teams have tiered storage enabled when retention time is exactly 3 days, so adapting this rule.
Better to enable it if possible than not.