### PR TITLE
DENA-671: Update millis in one month and year

### DIFF
--- a/rules/msk_topic_config.go
+++ b/rules/msk_topic_config.go
@@ -343,8 +343,8 @@ const (
 	retentionTimeAttr = "retention.ms"
 	millisInOneHour   = 60 * 60 * 1000
 	millisInOneDay    = 24 * millisInOneHour
-	millisInOneMonth  = 30 * millisInOneDay
-	millisInOneYear   = 365 * millisInOneDay
+	millisInOneMonth  = 2629800000
+	millisInOneYear   = 31556952000
 	// The threshold on retention time when remote storage is supported.
 	tieredStorageThresholdInDays    = 3
 	tieredStorageEnableAttr         = "remote.storage.enable"

--- a/rules/msk_topic_config_comments.md
+++ b/rules/msk_topic_config_comments.md
@@ -6,8 +6,8 @@ Topic configurations expressed in milliseconds must have comments explaining the
 The comments can be placed after the property definition on the same line or on the line before the definition.
 
 For computing the human-readable values it considers the following:
-- 1 month has 30 days
-- 1 year has 365 days
+- 1 month has `2629800000` millis which is 30.4375 days
+- 1 year has `31556952000` millis which is 365.2425 days
 
 It currently checks the properties:
 - retention.ms: explanation must start with `keep data`

--- a/rules/msk_topic_config_comments_test.go
+++ b/rules/msk_topic_config_comments_test.go
@@ -86,7 +86,7 @@ resource "kafka_topic" "topic_good_retention_comment_months" {
   name               = "topic_good_retention_comment_months"
   replication_factor = 3
   config = {
-    "retention.ms" = "5184000000" # keep data for 2 months 
+    "retention.ms" = "5259600000" # keep data for 2 months 
   }
 }`,
 		expected: []*helper.Issue{},
@@ -111,7 +111,7 @@ resource "kafka_topic" "topic_good_retention_comment_years" {
   name               = "topic_good_retention_comment_years"
   replication_factor = 3
   config = {
-    "retention.ms" = "31536000000" # keep data for 1 year 
+    "retention.ms" = "31556952000" # keep data for 1 year 
   }
 }`,
 		expected: []*helper.Issue{},
@@ -123,7 +123,7 @@ resource "kafka_topic" "topic_good_retention_comment_years" {
   name               = "topic_good_retention_comment_years"
   replication_factor = 3
   config = {
-    "retention.ms" = "47304000000" # keep data for 1.5 years 
+    "retention.ms" = "47335428000" # keep data for 1.5 years 
   }
 }`,
 		expected: []*helper.Issue{},
@@ -135,7 +135,7 @@ resource "kafka_topic" "topic_good_retention_comment_years" {
   name               = "topic_good_retention_comment_years"
   replication_factor = 3
   config = {
-    "retention.ms" = "6480000000" # keep data for 2.5 months 
+    "retention.ms" = "6574500000" # keep data for 2.5 months 
   }
 }`,
 		expected: []*helper.Issue{},
@@ -228,14 +228,14 @@ resource "kafka_topic" "topic_def" {
   name               = "topic_def"
   replication_factor = 3
   config = {
-    "max.compaction.lag.ms" = "2592000000"
+    "max.compaction.lag.ms" = "2629800000"
   }
 }`, fixed: `
 resource "kafka_topic" "topic_def" {
   name               = "topic_def"
   replication_factor = 3
   config = {
-    "max.compaction.lag.ms" = "2592000000" # allow not compacted keys maximum for 1 month
+    "max.compaction.lag.ms" = "2629800000" # allow not compacted keys maximum for 1 month
   }
 }`,
 		expected: []*helper.Issue{


### PR DESCRIPTION
We were getting diffs on the current kafka-cluster-config values.

Updated based on what popular converters say and on the criteria that more is better than less.
There are still diffs on the kafka-cluster-config values, but at least we'll unify these
