### PR TITLE
DENA-671: comments validation for properties with bytes

### DIFF
--- a/rules/msk_topic_config_comments.go
+++ b/rules/msk_topic_config_comments.go
@@ -374,26 +374,26 @@ func buildCommentForBytes(bytes int, baseComment string) string {
 }
 
 const (
-	bytesInOneKB = 1024
-	bytesInOneMB = 1024 * bytesInOneKB
-	bytesInOneGB = 1024 * bytesInOneMB
+	bytesInOneKiB = 1024
+	bytesInOneMiB = 1024 * bytesInOneKiB
+	bytesInOneGiB = 1024 * bytesInOneMiB
 )
 
 func determineByteUnits(bytes int) (float64, string) {
 	floatBytes := float64(bytes)
-	gbs := round(floatBytes / bytesInOneGB)
+	gbs := round(floatBytes / bytesInOneGiB)
 	if gbs >= 1 {
-		return gbs, "GB"
+		return gbs, "GiB"
 	}
 
-	mbs := round(floatBytes / bytesInOneMB)
+	mbs := round(floatBytes / bytesInOneMiB)
 	if mbs >= 1 {
-		return mbs, "MB"
+		return mbs, "MiB"
 	}
 
-	kbs := round(floatBytes / bytesInOneKB)
+	kbs := round(floatBytes / bytesInOneKiB)
 	if kbs >= 1 {
-		return kbs, "KB"
+		return kbs, "KiB"
 	}
 	return floatBytes, "B"
 }

--- a/rules/msk_topic_config_comments.go
+++ b/rules/msk_topic_config_comments.go
@@ -191,10 +191,7 @@ func (r *MSKTopicConfigCommentsRule) validateByteConfigValue(
 		return nil
 	}
 
-	if err = r.reportHumanReadableComment(runner, dataPair, key, msg); err != nil {
-		return err
-	}
-	return nil
+	return r.reportHumanReadableComment(runner, dataPair, key, msg)
 }
 
 func (r *MSKTopicConfigCommentsRule) reportHumanReadableComment(

--- a/rules/msk_topic_config_comments.go
+++ b/rules/msk_topic_config_comments.go
@@ -166,10 +166,7 @@ func (r *MSKTopicConfigCommentsRule) validateTimeConfigValue(
 		return nil
 	}
 
-	if err = r.reportHumanReadableComment(runner, timePair, key, msg); err != nil {
-		return err
-	}
-	return nil
+	return r.reportHumanReadableComment(runner, timePair, key, msg)
 }
 
 func (r *MSKTopicConfigCommentsRule) validateByteConfigValue(

--- a/rules/msk_topic_config_comments.go
+++ b/rules/msk_topic_config_comments.go
@@ -386,7 +386,7 @@ func determineByteUnits(bytes int) (float64, string) {
 	}
 
 	kbs := round(floatBytes / bytesInOneKB)
-	if mbs >= 1 {
+	if kbs >= 1 {
 		return kbs, "KB"
 	}
 	return floatBytes, "B"

--- a/rules/msk_topic_config_comments.go
+++ b/rules/msk_topic_config_comments.go
@@ -121,6 +121,12 @@ var configByteValueCommentInfos = []configValueCommentInfo{
 		baseComment:      "allow for a batch of records maximum",
 		issueWhenInvalid: true,
 	},
+	{
+		key:              "retention.bytes",
+		infiniteValue:    "-1",
+		baseComment:      "keep on each partition",
+		issueWhenInvalid: true,
+	},
 }
 
 func (r *MSKTopicConfigCommentsRule) validateConfigValuesInComments(
@@ -338,7 +344,7 @@ func (r *MSKTopicConfigCommentsRule) buildDataSizeComment(
 	}
 
 	if dataVal == configValueInfo.infiniteValue {
-		return fmt.Sprintf("# %s unlimited", configValueInfo.baseComment), nil
+		return fmt.Sprintf("# %s unlimited data", configValueInfo.baseComment), nil
 	}
 
 	byteVal, err := strconv.Atoi(dataVal)

--- a/rules/msk_topic_config_comments.md
+++ b/rules/msk_topic_config_comments.md
@@ -30,8 +30,8 @@ resource "kafka_topic" "good_topic" {
     # keep data in primary storage for 1 day
     "local.retention.ms"    = "86400000"
     "retention.ms"          = "2592000000" # keep data for 1 month
-    "max.message.bytes"     = "3145728"    # allow for a batch of records maximum 3MB
-    "retention.bytes"       = "1610612736" # keep on each partition 1.5GB
+    "max.message.bytes"     = "3145728"    # allow for a batch of records maximum 3MiB
+    "retention.bytes"       = "1610612736" # keep on each partition 1.5GiB
     "compression.type"      = "zstd"
   }
 }

--- a/rules/msk_topic_config_comments.md
+++ b/rules/msk_topic_config_comments.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-Topic configurations expressed in milliseconds must have comments explaining the property and including the human-readable value.
+Topic configurations expressed in milliseconds and bytes must have comments explaining the property and including the human-readable value.
 The comments can be placed after the property definition on the same line or on the line before the definition.
 
 For computing the human-readable values it considers the following:
@@ -13,7 +13,8 @@ It currently checks the properties:
 - retention.ms: explanation must start with `keep data`
 - local.retention.ms: explanation must start with `keep data in primary storage`
 - max.compaction.lag.ms: explanation must start with `allow not compacted keys maximum`
-
+- retention.bytes: explanation must start with `keep on each partition`
+- max.message.bytes: explanation must start with `allow for a batch of records maximum`
 ## Example
 
 ### Good example
@@ -28,7 +29,9 @@ resource "kafka_topic" "good_topic" {
     "cleanup.policy"        = "delete"
     # keep data in primary storage for 1 day
     "local.retention.ms"    = "86400000"
-    "retention.ms"          = "2592000000" # keep data for 1 month 
+    "retention.ms"          = "2592000000" # keep data for 1 month
+    "max.message.bytes"     = "3145728"    # allow for a batch of records maximum 3MB
+    "retention.bytes"       = "1610612736" # keep on each partition 1.5GB
     "compression.type"      = "zstd"
   }
 }

--- a/rules/msk_topic_config_comments_test.go
+++ b/rules/msk_topic_config_comments_test.go
@@ -445,6 +445,26 @@ resource "kafka_topic" "topic_def" {
 			},
 		},
 	},
+	{
+		name: "retention bytes invalid",
+		input: `
+resource "kafka_topic" "topic_def" {
+  name = "topic-def"
+  config = {
+    "retention.bytes" = "invalid-val"
+  }
+}`,
+		expected: []*helper.Issue{
+			{
+				Message: "retention.bytes must have a valid integer value expressed in bytes",
+				Range: hcl.Range{
+					Filename: fileName,
+					Start:    hcl.Pos{Line: 5, Column: 25},
+					End:      hcl.Pos{Line: 5, Column: 38},
+				},
+			},
+		},
+	},
 }
 
 func Test_MSKTopicConfigCommentsRule(t *testing.T) {

--- a/rules/msk_topic_config_comments_test.go
+++ b/rules/msk_topic_config_comments_test.go
@@ -326,7 +326,7 @@ resource "kafka_topic" "topic_def" {
 resource "kafka_topic" "topic_def" {
   name = "topic-def"
   config = {
-    "max.message.bytes" = "3145728" # allow for a batch of records maximum 3MB
+    "max.message.bytes" = "3145728" # allow for a batch of records maximum 3MiB
   }
 }`,
 		expected: []*helper.Issue{
@@ -346,7 +346,7 @@ resource "kafka_topic" "topic_def" {
 resource "kafka_topic" "topic_def" {
   name = "topic-def"
   config = {
-    "max.message.bytes" = "4509715661" # allow for a batch of records maximum 4.2GB
+    "max.message.bytes" = "4509715661" # allow for a batch of records maximum 4.2GiB
   }
 }`,
 		expected: []*helper.Issue{},
@@ -357,7 +357,7 @@ resource "kafka_topic" "topic_def" {
 resource "kafka_topic" "topic_def" {
   name = "topic-def"
   config = {
-    "max.message.bytes" = "204800" # allow for a batch of records maximum 200KB
+    "max.message.bytes" = "204800" # allow for a batch of records maximum 200KiB
   }
 }`,
 		expected: []*helper.Issue{},
@@ -405,7 +405,7 @@ resource "kafka_topic" "topic_def" {
 resource "kafka_topic" "topic_def" {
   name = "topic-def"
   config = {
-    "retention.bytes" = "1610612736" # keep on each partition 1.5GB
+    "retention.bytes" = "1610612736" # keep on each partition 1.5GiB
   }
 }`,
 		expected: []*helper.Issue{
@@ -425,7 +425,7 @@ resource "kafka_topic" "topic_def" {
 resource "kafka_topic" "topic_def" {
   name = "topic-def"
   config = {
-    "retention.bytes" = "-1" # keep on each partition 3MB
+    "retention.bytes" = "-1" # keep on each partition 3MiB
   }
 }`, fixed: `
 resource "kafka_topic" "topic_def" {

--- a/rules/msk_topic_config_comments_test.go
+++ b/rules/msk_topic_config_comments_test.go
@@ -341,6 +341,39 @@ resource "kafka_topic" "topic_def" {
 		},
 	},
 	{
+		name: "max message bytes with value in gigabytes",
+		input: `
+resource "kafka_topic" "topic_def" {
+  name = "topic-def"
+  config = {
+    "max.message.bytes" = "4509715661" # allow for a batch of records maximum 4.2GB
+  }
+}`,
+		expected: []*helper.Issue{},
+	},
+	{
+		name: "max message bytes with value in kilos",
+		input: `
+resource "kafka_topic" "topic_def" {
+  name = "topic-def"
+  config = {
+    "max.message.bytes" = "204800" # allow for a batch of records maximum 200KB
+  }
+}`,
+		expected: []*helper.Issue{},
+	},
+	{
+		name: "max message bytes with value in bytes",
+		input: `
+resource "kafka_topic" "topic_def" {
+  name = "topic-def"
+  config = {
+    "max.message.bytes" = "100" # allow for a batch of records maximum 100B
+  }
+}`,
+		expected: []*helper.Issue{},
+	},
+	{
 		name: "max message bytes invalid",
 		input: `
 resource "kafka_topic" "topic_def" {


### PR DESCRIPTION
Validate the comments for properties with byte values.

This version generates the changes in here: https://github.com/utilitywarehouse/kafka-cluster-config/pull/678
