### PR TITLE
DENA-671: Move constants closer to their usage

### DIFF
--- a/rules/msk_topic_config.go
+++ b/rules/msk_topic_config.go
@@ -341,10 +341,6 @@ func (r *MSKTopicConfigRule) getAndValidateCleanupPolicyValue(
 
 const (
 	retentionTimeAttr = "retention.ms"
-	millisInOneHour   = 60 * 60 * 1000
-	millisInOneDay    = 24 * millisInOneHour
-	millisInOneMonth  = 30 * millisInOneDay
-	millisInOneYear   = 365 * millisInOneDay
 	// The threshold on retention time when remote storage is supported.
 	tieredStorageThresholdInDays    = 3
 	tieredStorageEnableAttr         = "remote.storage.enable"

--- a/rules/msk_topic_config_comments.go
+++ b/rules/msk_topic_config_comments.go
@@ -405,6 +405,13 @@ func round(val float64) float64 {
 	return math.Round(val*10) / 10
 }
 
+const (
+	millisInOneHour  = 60 * 60 * 1000
+	millisInOneDay   = 24 * millisInOneHour
+	millisInOneMonth = 30 * millisInOneDay
+	millisInOneYear  = 365 * millisInOneDay
+)
+
 func determineTimeUnits(millis int) (float64, string) {
 	floatMillis := float64(millis)
 	timeInYears := round(floatMillis / millisInOneYear)


### PR DESCRIPTION
Minor refactor: moved these constants close to the func that uses them