### PR TITLE
Fix the cert_common_name in the example

### DIFF
--- a/rules/msk_app_topics.md
+++ b/rules/msk_app_topics.md
@@ -56,7 +56,7 @@ resource "kafka_topic" "example_topic" {
 # second-team defines their consumer inside first-team's module
 module "second_team_indexer" {
   source           = "../../../modules/tls-app"
-  cert_common_name = "second-team/example-consumer"
+  cert_common_name = "second-team/indexer"
 
   # OK: consume topic is defined in this module
   consume_topics   = [kafka_topic.example_topic.name]


### PR DESCRIPTION
This was spotted in this thread: https://utilitywarehouse.slack.com/archives/C0536L8V7EU/p1730825366760479?thread_ts=1730824584.479629&cid=C0536L8V7EU