### PR TITLE
handle non string topic names

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
 # pin to the version specified in go.mod to avoid inconsistent behaviour
 # on systems that have an older version of Go installed
 default_language_version:
-  golang: 1.22.0
+  golang: 1.23.0
 repos:
 -   repo: https://github.com/golangci/golangci-lint
-    rev: v1.59.1
+    rev: v1.63.4
     hooks:
     -   id: golangci-lint-full
     -   id: golangci-lint-config-verify
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
     -   id: check-yaml
         args: [--allow-multiple-documents]

--- a/rules/msk_app_topics.go
+++ b/rules/msk_app_topics.go
@@ -153,6 +153,22 @@ func (r *MSKAppTopicsRule) reportExternalTopics(
 		return fmt.Errorf("evaluating topic names: %w", diags)
 	}
 	for _, v := range val.AsValueSlice() {
+		if v.Type() != cty.String {
+			err := runner.EmitIssue(
+				r,
+				fmt.Sprintf(
+					"value for '%s' must be a string, not: %s",
+					attrName,
+					v.Type().FriendlyName(),
+				),
+				topicAttr.Range,
+			)
+			if err != nil {
+				return fmt.Errorf("emitting issue: %w", err)
+			}
+			continue
+		}
+
 		name := v.AsString()
 		if _, ok := moduleTopicNames[name]; !ok {
 			err := runner.EmitIssue(

--- a/rules/msk_app_topics_test.go
+++ b/rules/msk_app_topics_test.go
@@ -90,6 +90,31 @@ module "consumer" {
 			},
 		},
 		{
+			name: "topic name is not string",
+			files: map[string]string{
+				"file.tf": `
+resource "kafka_topic" "my_topic" {
+	name = "my_topic"
+}
+
+module "consumer" {
+	consume_topics = [kafka_topic.my_topic]
+}
+`,
+			},
+			expected: []*helper.Issue{
+				{
+					Rule:    rule,
+					Message: "value for 'consume_topics' must be a string, not: object",
+					Range: hcl.Range{
+						Filename: "file.tf",
+						Start:    hcl.Pos{Line: 7, Column: 2},
+						End:      hcl.Pos{Line: 7, Column: 41},
+					},
+				},
+			},
+		},
+		{
 			name: "external topic defined outside of consumer/producer",
 			files: map[string]string{
 				"file.tf": `


### PR DESCRIPTION
- Update `pre-commit`

    Via `pre-commit autoupdate`, this was mostly because the old version of
    `golangci-lint` had a tendency of just eating up all my RAM and OOMing.
    The updated version is much more nicely behaved.

- Fix panic on non-string topic name

    A panic results in an unhelpful message when running the plugin:

        Failed to check ruleset; error reading from server: EOF

    So report an error here instead.

    There is potential for similar behaviour if `consume_topics` is not a
    list, in which case `AsValueSlice` would panic, but I'm content to not
    be too defensive here if no-ones needing that change.

Ticket:  DENA-1175