### PR TITLE
Fix: handle BoundExpr-wrapped config when resource uses count/for_each

### DIFF
--- a/rules/msk_topic_config.go
+++ b/rules/msk_topic_config.go
@@ -149,9 +149,15 @@ func (r *MSKTopicConfigRule) validateAndGetConfigAttr(
 }
 
 func constructConfigKeyToPairMap(configAttr *hclext.Attribute) (map[string]hcl.KeyValuePair, error) {
-	configExpr, ok := configAttr.Expr.(*hclsyntax.ObjectConsExpr)
+	// hclext may wrap expressions in BoundExpr when resolving values (e.g. when
+	// a resource uses count/for_each with variable references). Unwrap first.
+	rawExpr := configAttr.Expr
+	if bound, ok := rawExpr.(*hclext.BoundExpr); ok {
+		rawExpr = bound.UnwrapExpression()
+	}
+	configExpr, ok := rawExpr.(*hclsyntax.ObjectConsExpr)
 	if !ok {
-		return nil, fmt.Errorf("could not convert 'config' of type %T to hclsyntax.ObjectConsExpr", configExpr)
+		return nil, fmt.Errorf("could not convert 'config' of type %T to hclsyntax.ObjectConsExpr", rawExpr)
 	}
 
 	res := make(map[string]hcl.KeyValuePair, len(configExpr.ExprMap()))

--- a/rules/msk_topic_config_test.go
+++ b/rules/msk_topic_config_test.go
@@ -900,6 +900,29 @@ resource "kafka_topic" "good topic" {
 }`,
 		expected: []*helper.Issue{},
 	},
+	{
+		name: "good topic with count driven by a boolean variable",
+		input: `
+variable "enable_topic" {
+  type    = bool
+  default = true
+}
+resource "kafka_topic" "good_topic" {
+  count              = var.enable_topic ? 1 : 0
+  name               = "pubsub.good-topic.normal"
+  replication_factor = 3
+  partitions         = 5
+  config = {
+    "remote.storage.enable" = "true"
+    "local.retention.ms"    = "86400000"
+    "retention.ms"          = "259200000"
+    "max.message.bytes"     = "104857600"
+    "compression.type"      = "zstd"
+    "cleanup.policy"        = "delete"
+  }
+}`,
+		expected: []*helper.Issue{},
+	},
 }
 
 func Test_MSKTopicConfigRule(t *testing.T) {

--- a/rules/msk_topic_config_test.go
+++ b/rules/msk_topic_config_test.go
@@ -4,10 +4,13 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	"github.com/terraform-linters/tflint-plugin-sdk/helper"
 	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/zclconf/go-cty/cty"
 )
 
 type topicConfigTestCase struct {
@@ -900,29 +903,6 @@ resource "kafka_topic" "good topic" {
 }`,
 		expected: []*helper.Issue{},
 	},
-	{
-		name: "good topic with count driven by a boolean variable",
-		input: `
-variable "enable_topic" {
-  type    = bool
-  default = true
-}
-resource "kafka_topic" "good_topic" {
-  count              = var.enable_topic ? 1 : 0
-  name               = "pubsub.good-topic.normal"
-  replication_factor = 3
-  partitions         = 5
-  config = {
-    "remote.storage.enable" = "true"
-    "local.retention.ms"    = "86400000"
-    "retention.ms"          = "259200000"
-    "max.message.bytes"     = "104857600"
-    "compression.type"      = "zstd"
-    "cleanup.policy"        = "delete"
-  }
-}`,
-		expected: []*helper.Issue{},
-	},
 }
 
 func Test_MSKTopicConfigRule(t *testing.T) {
@@ -959,4 +939,38 @@ func setExpectedRule(expected helper.Issues, rule tflint.Rule) {
 	for _, exp := range expected {
 		exp.Rule = rule
 	}
+}
+
+func Test_constructConfigKeyToPairMap_BoundExpr(t *testing.T) {
+	// When tflint evaluates resources with count/for_each that reference
+	// variables, it wraps attribute expressions in hclext.BoundExpr.
+	// constructConfigKeyToPairMap must unwrap BoundExpr to access the
+	// underlying ObjectConsExpr.
+	src := `config = {
+  "cleanup.policy"   = "delete"
+  "compression.type" = "zstd"
+}`
+	f, diags := hclsyntax.ParseConfig([]byte(src), "test.tf", hcl.Pos{Line: 1, Column: 1})
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	attrs, diags := f.Body.JustAttributes()
+	require.False(t, diags.HasErrors(), diags.Error())
+
+	configHCLAttr := attrs["config"]
+	require.NotNil(t, configHCLAttr)
+
+	// Wrap the expression in BoundExpr, simulating what tflint does over gRPC
+	// for resources with count/for_each.
+	wrappedExpr := hclext.BindValue(cty.EmptyObjectVal, configHCLAttr.Expr)
+
+	boundAttr := &hclext.Attribute{
+		Name:  "config",
+		Expr:  wrappedExpr,
+		Range: configHCLAttr.Range,
+	}
+
+	result, err := constructConfigKeyToPairMap(boundAttr)
+	require.NoError(t, err)
+	assert.Contains(t, result, "cleanup.policy")
+	assert.Contains(t, result, "compression.type")
 }


### PR DESCRIPTION
## Problem

When a `kafka_topic` resource uses `count` or `for_each` with a variable reference (e.g. `count = var.enable_topic ? 1 : 0`), the rule would fail with:

```
Failed to check ruleset; failed to check "msk_topic_config" rule: could not convert 'config' of type *hclsyntax.ObjectConsExpr to hclsyntax.ObjectConsExpr
```

## Root Cause

In the real tflint execution flow, attribute expressions are transmitted from the tflint host to the plugin over gRPC. During deserialisation, the plugin SDK wraps each expression in an `hclext.BoundExpr` — a thin wrapper that short-circuits value resolution to return the pre-evaluated value sent by the host.

`constructConfigKeyToPairMap` was directly type-asserting `configAttr.Expr` to `*hclsyntax.ObjectConsExpr`, which fails when the expression has been wrapped in `*hclext.BoundExpr`. Resources without `count`/`for_each` were unaffected because tflint evaluates those attributes without binding.

There was also a secondary bug in the error message: `%T` was applied to the nil result of the failed assertion (`configExpr`) rather than to `configAttr.Expr`, so the error always printed `*hclsyntax.ObjectConsExpr` instead of the actual unexpected type, making it harder to diagnose.

## Fix

Before the type assertion, unwrap `BoundExpr` if present to recover the original `*hclsyntax.ObjectConsExpr`:

```go
rawExpr := configAttr.Expr
if bound, ok := rawExpr.(*hclext.BoundExpr); ok {
    rawExpr = bound.UnwrapExpression()
}
configExpr, ok := rawExpr.(*hclsyntax.ObjectConsExpr)
```

The error message is also fixed to print the type of `rawExpr` (the actual unexpected type) rather than the nil assertion result.

## Test

A unit test (`Test_constructConfigKeyToPairMap_BoundExpr`) is added that directly calls `constructConfigKeyToPairMap` with a `BoundExpr`-wrapped config attribute, reproducing the gRPC wrapping that the `helper.TestRunner` does not simulate. The test fails without the fix and passes with it.